### PR TITLE
Change make file to put coverage report in the `target` directory to keep things tidy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ publish:
 .PHONY: coverage
 coverage:
 	cargo install cargo-tarpaulin
-	mkdir -p coverage
-	cargo tarpaulin --all-features --workspace --timeout 120 --out Xml
+	mkdir -p target/coverage
+	cargo tarpaulin --all-features --workspace --timeout 120 --out Xml --output-dir ./target/coverage
 
 .PHONY: coverage-html
 coverage-html:
 	cargo install cargo-tarpaulin
-	mkdir -p coverage
-	cargo tarpaulin --all-features --workspace --timeout 120 --out Html
+	mkdir -p target/coverage
+	cargo tarpaulin --all-features --workspace --timeout 120 --out Html --output-dir ./target/coverage


### PR DESCRIPTION
I noticed that a `coverage` directory was being created, but never used, and also not being cleaned up by the clean target. I figure putting the directory under `target` will keep things tidy and also make sure it's included in `clean`.

I also checked the workflows and it looked to my like they were calling `tarpaulin` directly (not via `make`) so this change shouldn't impact them.
