### PR TITLE
feat(market_data): implement REST endpoints (#12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ The library leverages Rust's performance and concurrency advantages, making it s
 ## Features
 
 1. **Trade Execution**: Implement order placement, modification, and cancellation.
-2. **Real-time Market Data**: Access live quotes, order book data, and trade information.
+2. **Real-time Market Data**: Access live quotes, option chains, historical OHLCV bars,
+   intraday time-and-sales, market clock / calendar, and ETB / lookup / search endpoints
+   via typed REST bindings (`MarketData` trait).
 3. **Portfolio Management**: Retrieve account information, positions, and performance metrics.
 4. **Historical Data**: Fetch and analyze historical price and volume data.
 5. **Streaming Data**: Utilize WebSocket connections for real-time data feeds.

--- a/examples/market_data_quotes/main.rs
+++ b/examples/market_data_quotes/main.rs
@@ -1,0 +1,40 @@
+//! Example demonstrating `get_quotes` against the Tradier Market Data API.
+//!
+//! Run with:
+//!
+//! ```text
+//! TRADIER_ACCESS_TOKEN=... \
+//! cargo run --example market_data_quotes
+//! ```
+//!
+//! Set `TRADIER_REST_BASE_URL` to `https://sandbox.tradier.com` to point at
+//! the sandbox instead of production.
+use tracing::info;
+use tradier::non_blocking::operation::MarketData;
+use tradier::non_blocking::Client;
+use tradier::types::{Greeks, Symbol, Symbols};
+use tradier::utils::logger::setup_logger;
+use tradier::Config;
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn core::error::Error>> {
+    setup_logger();
+
+    let config = Config::new();
+    info!("Config: {:?}", &config);
+
+    let client = Client::new(config);
+
+    let symbols = Symbols::new([
+        "AAPL".parse::<Symbol>()?,
+        "MSFT".parse::<Symbol>()?,
+        "SPY".parse::<Symbol>()?,
+    ]);
+
+    // Fetch quotes including Greeks (Greeks only apply to option quotes).
+    let response = client.get_quotes(&symbols, Some(Greeks::new(true))).await?;
+
+    info!("Quotes response: {:#?}", response);
+
+    Ok(())
+}

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -19,6 +19,7 @@
 //! # When **not** to use
 //! - Any code already running under Tokio (e.g., `#[tokio::main]`, `#[tokio::test]`).
 //!   In those cases, import and call the async client directly.
+use chrono::{DateTime, NaiveDate, Utc};
 use tokio::runtime::{Handle, Runtime};
 
 use crate::{
@@ -30,6 +31,19 @@ use crate::{
     accounts::{api::blocking::Accounts, api::non_blocking::Accounts as NonBlockingAccounts},
     client::non_blocking::TradierRestClient as AsyncClient,
     common::SortOrder,
+    market_data::{
+        api::blocking::MarketData,
+        api::non_blocking::MarketData as NonBlockingMarketData,
+        types::{
+            CalendarMonth, CalendarYear, DelayedFlag, Exchanges, GetCalendarResponse,
+            GetClockResponse, GetEtbSecuritiesResponse, GetHistoricalQuotesResponse,
+            GetOptionChainsResponse, GetOptionExpirationsResponse, GetOptionStrikesResponse,
+            GetQuotesResponse, GetTimeAndSalesResponse, Greeks, HistoryInterval, IncludeAllRoots,
+            IncludeStrikes, IndexesFlag, LookupOptionSymbolsResponse, LookupSymbolResponse,
+            SearchCompaniesResponse, SecurityTypes, SessionFilter, Symbol, Symbols,
+            TimeSalesInterval,
+        },
+    },
     user::{api::blocking::User, api::non_blocking::User as NonBlockingUser, UserProfileResponse},
     utils::Sealed,
     Config, Result,
@@ -173,6 +187,128 @@ impl Accounts for BlockingTradierRestClient {
             limit,
             include_tags,
         ))
+    }
+}
+
+impl MarketData for BlockingTradierRestClient {
+    fn get_quotes(&self, symbols: &Symbols, greeks: Option<Greeks>) -> Result<GetQuotesResponse> {
+        self.runtime
+            .block_on(self.rest_client.get_quotes(symbols, greeks))
+    }
+
+    fn post_quotes(&self, symbols: &Symbols, greeks: Option<Greeks>) -> Result<GetQuotesResponse> {
+        self.runtime
+            .block_on(self.rest_client.post_quotes(symbols, greeks))
+    }
+
+    fn get_option_chains(
+        &self,
+        symbol: &Symbol,
+        expiration: &NaiveDate,
+        greeks: Option<Greeks>,
+    ) -> Result<GetOptionChainsResponse> {
+        self.runtime.block_on(
+            self.rest_client
+                .get_option_chains(symbol, expiration, greeks),
+        )
+    }
+
+    fn get_option_strikes(
+        &self,
+        symbol: &Symbol,
+        expiration: &NaiveDate,
+    ) -> Result<GetOptionStrikesResponse> {
+        self.runtime
+            .block_on(self.rest_client.get_option_strikes(symbol, expiration))
+    }
+
+    fn get_option_expirations(
+        &self,
+        symbol: &Symbol,
+        include_all_roots: Option<IncludeAllRoots>,
+        strikes: Option<IncludeStrikes>,
+    ) -> Result<GetOptionExpirationsResponse> {
+        self.runtime
+            .block_on(
+                self.rest_client
+                    .get_option_expirations(symbol, include_all_roots, strikes),
+            )
+    }
+
+    fn lookup_option_symbols(&self, underlying: &Symbol) -> Result<LookupOptionSymbolsResponse> {
+        self.runtime
+            .block_on(self.rest_client.lookup_option_symbols(underlying))
+    }
+
+    fn get_historical_quotes(
+        &self,
+        symbol: &Symbol,
+        interval: Option<HistoryInterval>,
+        start: Option<&NaiveDate>,
+        end: Option<&NaiveDate>,
+        session_filter: Option<SessionFilter>,
+    ) -> Result<GetHistoricalQuotesResponse> {
+        self.runtime
+            .block_on(self.rest_client.get_historical_quotes(
+                symbol,
+                interval,
+                start,
+                end,
+                session_filter,
+            ))
+    }
+
+    fn get_time_and_sales(
+        &self,
+        symbol: &Symbol,
+        interval: Option<TimeSalesInterval>,
+        start: Option<&DateTime<Utc>>,
+        end: Option<&DateTime<Utc>>,
+        session_filter: Option<SessionFilter>,
+    ) -> Result<GetTimeAndSalesResponse> {
+        self.runtime.block_on(self.rest_client.get_time_and_sales(
+            symbol,
+            interval,
+            start,
+            end,
+            session_filter,
+        ))
+    }
+
+    fn get_etb_securities(&self) -> Result<GetEtbSecuritiesResponse> {
+        self.runtime.block_on(self.rest_client.get_etb_securities())
+    }
+
+    fn get_clock(&self, delayed: Option<DelayedFlag>) -> Result<GetClockResponse> {
+        self.runtime.block_on(self.rest_client.get_clock(delayed))
+    }
+
+    fn get_calendar(
+        &self,
+        month: Option<CalendarMonth>,
+        year: Option<CalendarYear>,
+    ) -> Result<GetCalendarResponse> {
+        self.runtime
+            .block_on(self.rest_client.get_calendar(month, year))
+    }
+
+    fn search_companies(
+        &self,
+        q: &str,
+        indexes: Option<IndexesFlag>,
+    ) -> Result<SearchCompaniesResponse> {
+        self.runtime
+            .block_on(self.rest_client.search_companies(q, indexes))
+    }
+
+    fn lookup_symbol(
+        &self,
+        q: &str,
+        exchanges: Option<&Exchanges>,
+        types: Option<&SecurityTypes>,
+    ) -> Result<LookupSymbolResponse> {
+        self.runtime
+            .block_on(self.rest_client.lookup_symbol(q, exchanges, types))
     }
 }
 
@@ -538,5 +674,671 @@ mod test {
         let config = Config::new();
         let sut = BlockingTradierRestClient::new(config);
         assert!(sut.is_err());
+    }
+}
+
+#[cfg(test)]
+mod market_data_tests {
+    use super::BlockingTradierRestClient;
+    use crate::{
+        market_data::{
+            api::blocking::MarketData,
+            test_support::{
+                GetCalendarResponseWire, GetClockResponseWire, GetEtbSecuritiesResponseWire,
+                GetHistoricalQuotesResponseWire, GetOptionChainsResponseWire,
+                GetOptionExpirationsResponseWire, GetOptionStrikesResponseWire,
+                GetQuotesResponseWire, GetTimeAndSalesResponseWire,
+                LookupOptionSymbolsResponseWire, LookupSymbolResponseWire,
+                SearchCompaniesResponseWire,
+            },
+            types::{
+                CalendarMonth, CalendarYear, DelayedFlag, Exchanges, Greeks, HistoryInterval,
+                IncludeAllRoots, IncludeStrikes, IndexesFlag, SecurityTypes, SessionFilter, Symbol,
+                Symbols, TimeSalesInterval,
+            },
+        },
+        utils::tests::with_env_vars,
+        Config,
+    };
+    use chrono::{NaiveDate, TimeZone, Utc};
+    use httpmock::MockServer;
+    use proptest::prelude::*;
+    use std::cell::RefCell;
+
+    fn make_symbol(s: &str) -> Symbol {
+        s.parse().expect("valid symbol")
+    }
+
+    fn make_symbols(syms: &[&str]) -> Symbols {
+        Symbols::new(syms.iter().map(|s| make_symbol(s)))
+    }
+
+    fn make_client(server: &MockServer) -> BlockingTradierRestClient {
+        let mut config = Config::new();
+        // Swap the base URL to point at the mock server.
+        config.rest_api.base_url = server.base_url();
+        BlockingTradierRestClient::new(config).expect("client to initialize")
+    }
+
+    fn run_with_env<F: FnOnce()>(server: &MockServer, f: F) {
+        with_env_vars(
+            vec![
+                ("TRADIER_REST_BASE_URL", &server.base_url()),
+                ("TRADIER_ACCESS_TOKEN", "testToken"),
+            ],
+            f,
+        );
+    }
+
+    // 1. GET /v1/markets/quotes ------------------------------------------------
+
+    #[test]
+    fn test_get_quotes_happy_path_returns_decoded_struct() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetQuotesResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/v1/markets/quotes")
+                        .header("accept", "application/json")
+                        .query_param("symbols", "AAPL,MSFT")
+                        .query_param("greeks", "true");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_quotes(
+                        &make_symbols(&["AAPL", "MSFT"]),
+                        Some(Greeks::new(true)),
+                    );
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_quotes_without_greeks_omits_query_param() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/v1/markets/quotes")
+                .query_param("symbols", "AAPL")
+                .is_true(|req| req.query_params().iter().all(|(k, _)| k != "greeks"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"quotes":{}}"#);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_quotes(&make_symbols(&["AAPL"]), None);
+            assert!(resp.is_ok());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_quotes_server_error_surfaces_network_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/v1/markets/quotes");
+            then.status(500)
+                .header("content-type", "application/json")
+                .body("not json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_quotes(&make_symbols(&["AAPL"]), None);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_quotes_malformed_body_surfaces_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/v1/markets/quotes");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{ not-json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_quotes(&make_symbols(&["AAPL"]), None);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_quotes_four_hundred_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/v1/markets/quotes");
+            then.status(400)
+                .header("content-type", "application/json")
+                .body(r#"{"fault":{"faultstring":"bad"}}"#);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_quotes(&make_symbols(&["AAPL"]), None);
+            // The client deserializes JSON bodies even on non-2xx because reqwest
+            // does not automatically raise on status. The body here is valid JSON
+            // but does not match GetQuotesResponse, so deserialization must fail.
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // 2. POST /v1/markets/quotes ----------------------------------------------
+
+    #[test]
+    fn test_post_quotes_happy_path_posts_form_body() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.method(httpmock::Method::POST)
+                .path("/v1/markets/quotes")
+                .header("accept", "application/json")
+                .body_includes("symbols=AAPL%2CMSFT")
+                .body_includes("greeks=true");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"quotes":{}}"#);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp =
+                client.post_quotes(&make_symbols(&["AAPL", "MSFT"]), Some(Greeks::new(true)));
+            assert!(resp.is_ok());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_post_quotes_without_greeks_form_body_has_no_greeks_field() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.method(httpmock::Method::POST)
+                .path("/v1/markets/quotes")
+                .body_includes("symbols=AAPL")
+                .is_true(|req| !req.body_string().contains("greeks"));
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"quotes":{}}"#);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.post_quotes(&make_symbols(&["AAPL"]), None);
+            assert!(resp.is_ok());
+            op.assert();
+        });
+    }
+
+    // 3. GET /v1/markets/options/chains ---------------------------------------
+
+    #[test]
+    fn test_get_option_chains_happy_path_verifies_query_params() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetOptionChainsResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/v1/markets/options/chains")
+                        .query_param("symbol", "AAPL")
+                        .query_param("expiration", "2024-06-21")
+                        .query_param("greeks", "false");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let expiration = NaiveDate::from_ymd_opt(2024, 6, 21).unwrap();
+                    let resp = client.get_option_chains(
+                        &make_symbol("AAPL"),
+                        &expiration,
+                        Some(Greeks::new(false)),
+                    );
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_option_chains_server_error_surfaces_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/v1/markets/options/chains");
+            then.status(503);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let expiration = NaiveDate::from_ymd_opt(2024, 6, 21).unwrap();
+            let resp = client.get_option_chains(&make_symbol("AAPL"), &expiration, None);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // 4. GET /v1/markets/options/strikes --------------------------------------
+
+    #[test]
+    fn test_get_option_strikes_happy_path_returns_decoded_struct() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetOptionStrikesResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/options/strikes")
+                        .query_param("symbol", "AAPL")
+                        .query_param("expiration", "2024-06-21");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let expiration = NaiveDate::from_ymd_opt(2024, 6, 21).unwrap();
+                    let resp = client
+                        .get_option_strikes(&make_symbol("AAPL"), &expiration);
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    // 5. GET /v1/markets/options/expirations ----------------------------------
+
+    #[test]
+    fn test_get_option_expirations_happy_path_verifies_query_params() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetOptionExpirationsResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/options/expirations")
+                        .query_param("symbol", "AAPL")
+                        .query_param("includeAllRoots", "true")
+                        .query_param("strikes", "true");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_option_expirations(
+                        &make_symbol("AAPL"),
+                        Some(IncludeAllRoots::new(true)),
+                        Some(IncludeStrikes::new(true)),
+                    );
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    // 6. GET /v1/markets/options/lookup ---------------------------------------
+
+    #[test]
+    fn test_lookup_option_symbols_happy_path_returns_decoded_struct() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<LookupOptionSymbolsResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/options/lookup")
+                        .query_param("underlying", "AAPL");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.lookup_option_symbols(&make_symbol("AAPL"));
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    // 7. GET /v1/markets/history ----------------------------------------------
+
+    #[test]
+    fn test_get_historical_quotes_happy_path_verifies_all_query_params() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetHistoricalQuotesResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/history")
+                        .query_param("symbol", "AAPL")
+                        .query_param("interval", "daily")
+                        .query_param("start", "2024-01-01")
+                        .query_param("end", "2024-01-31")
+                        .query_param("session_filter", "open");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let start = NaiveDate::from_ymd_opt(2024, 1, 1).unwrap();
+                    let end = NaiveDate::from_ymd_opt(2024, 1, 31).unwrap();
+                    let resp = client.get_historical_quotes(
+                        &make_symbol("AAPL"),
+                        Some(HistoryInterval::Daily),
+                        Some(&start),
+                        Some(&end),
+                        Some(SessionFilter::Open),
+                    );
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_historical_quotes_with_no_options_sends_only_symbol() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/v1/markets/history")
+                .query_param("symbol", "AAPL")
+                .is_true(|req| {
+                    req.query_params()
+                        .iter()
+                        .filter(|(k, _)| k != "symbol")
+                        .count()
+                        == 0
+                });
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"history": null}"#);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_historical_quotes(&make_symbol("AAPL"), None, None, None, None);
+            assert!(resp.is_ok());
+            op.assert();
+        });
+    }
+
+    // 8. GET /v1/markets/timesales --------------------------------------------
+
+    #[test]
+    fn test_get_time_and_sales_happy_path_verifies_all_query_params() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetTimeAndSalesResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/timesales")
+                        .query_param("symbol", "AAPL")
+                        .query_param("interval", "5min")
+                        .query_param("start", "2024-01-15 09:30")
+                        .query_param("end", "2024-01-15 16:00")
+                        .query_param("session_filter", "all");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let start = Utc.with_ymd_and_hms(2024, 1, 15, 9, 30, 0).unwrap();
+                    let end = Utc.with_ymd_and_hms(2024, 1, 15, 16, 0, 0).unwrap();
+                    let resp = client.get_time_and_sales(
+                        &make_symbol("AAPL"),
+                        Some(TimeSalesInterval::FiveMinutes),
+                        Some(&start),
+                        Some(&end),
+                        Some(SessionFilter::All),
+                    );
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    // 9. GET /v1/markets/etb --------------------------------------------------
+
+    #[test]
+    fn test_get_etb_securities_happy_path_returns_decoded_struct() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetEtbSecuritiesResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/etb");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_etb_securities();
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_etb_securities_not_authorized_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/v1/markets/etb");
+            then.status(401)
+                .header("content-type", "application/json")
+                .body("\"not a json object\"");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_etb_securities();
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // 10. GET /v1/markets/clock -----------------------------------------------
+
+    #[test]
+    fn test_get_clock_happy_path_verifies_delayed_query_param() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetClockResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/clock")
+                        .query_param("delayed", "true");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_clock(Some(DelayedFlag::new(true)));
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_clock_without_delayed_omits_query_param() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/v1/markets/clock")
+                .is_true(|req| req.query_params().iter().all(|(k, _)| k != "delayed"));
+            then.status(200).header("content-type", "application/json").body(
+                r#"{"clock":{"date":"2024-01-01","description":"Market is open","state":"open","timestamp":1,"next_change":"","next_state":"closed"}}"#,
+            );
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_clock(None);
+            assert!(resp.is_ok());
+            op.assert();
+        });
+    }
+
+    // 11. GET /v1/markets/calendar --------------------------------------------
+
+    #[test]
+    fn test_get_calendar_happy_path_verifies_month_year_params() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<GetCalendarResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/calendar")
+                        .query_param("month", "6")
+                        .query_param("year", "2024");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_calendar(
+                        Some(CalendarMonth::new(6).unwrap()),
+                        Some(CalendarYear::new(2024)),
+                    );
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    // 12. GET /v1/markets/search ----------------------------------------------
+
+    #[test]
+    fn test_search_companies_happy_path_returns_decoded_struct() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<SearchCompaniesResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/search")
+                        .query_param("q", "apple")
+                        .query_param("indexes", "false");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.search_companies("apple", Some(IndexesFlag::new(false)));
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    // 13. GET /v1/markets/lookup ----------------------------------------------
+
+    #[test]
+    fn test_lookup_symbol_happy_path_verifies_query_params() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(response in any::<LookupSymbolResponseWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.path("/v1/markets/lookup")
+                        .query_param("q", "goog")
+                        .query_param("exchanges", "N,Q")
+                        .query_param("types", "stock,etf");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&response).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let exchanges = Exchanges::new(vec!["N".into(), "Q".into()]);
+                    let types = SecurityTypes::new(vec!["stock".into(), "etf".into()]);
+                    let resp = client.lookup_symbol(
+                        "goog",
+                        Some(&exchanges),
+                        Some(&types),
+                    );
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_lookup_symbol_with_empty_filters_omits_query_params() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/v1/markets/lookup")
+                .query_param("q", "aap")
+                .is_true(|req| {
+                    req.query_params()
+                        .iter()
+                        .all(|(k, _)| k != "exchanges" && k != "types")
+                });
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(r#"{"securities": null}"#);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.lookup_symbol("aap", None, None);
+            assert!(resp.is_ok());
+            op.assert();
+        });
+    }
+
+    // Network error case — the server has no route for this path.
+    #[test]
+    fn test_network_error_when_server_refuses_connection() {
+        // Point at a port no one is listening on.
+        let mut cfg = Config::new();
+        cfg.credentials.access_token = Some("t".into());
+        cfg.rest_api.base_url = "http://127.0.0.1:1".into();
+        let client = BlockingTradierRestClient::new(cfg).expect("client");
+        let resp = client.get_etb_securities();
+        assert!(resp.is_err());
     }
 }

--- a/src/client/non_blocking.rs
+++ b/src/client/non_blocking.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, NaiveDate, Utc};
 use url::Url;
 
 use crate::{
@@ -10,6 +11,18 @@ use crate::{
     },
     common::SortOrder,
     config::Config,
+    market_data::{
+        api::non_blocking::MarketData,
+        types::{
+            format_naive_date, format_timesales_datetime, CalendarMonth, CalendarYear, DelayedFlag,
+            Exchanges, GetCalendarResponse, GetClockResponse, GetEtbSecuritiesResponse,
+            GetHistoricalQuotesResponse, GetOptionChainsResponse, GetOptionExpirationsResponse,
+            GetOptionStrikesResponse, GetQuotesResponse, GetTimeAndSalesResponse, Greeks,
+            HistoryInterval, IncludeAllRoots, IncludeStrikes, IndexesFlag,
+            LookupOptionSymbolsResponse, LookupSymbolResponse, SearchCompaniesResponse,
+            SecurityTypes, SessionFilter, Symbol, Symbols, TimeSalesInterval,
+        },
+    },
     types::{GetAccountHistoryResponse, GetAccountPositionsResponse},
     user::{api::non_blocking::User, UserProfileResponse},
     utils::Sealed,
@@ -54,6 +67,32 @@ impl TradierRestClient {
             .bearer_auth(bearer_token)
             .header("accept", "application/json")
             .send()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    /// POSTs a form body and parses the JSON response into `T`.
+    async fn post_form<T, I, K, V>(&self, url: Url, form: I) -> Result<T>
+    where
+        T: serde::de::DeserializeOwned,
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<str>,
+        V: AsRef<str>,
+    {
+        let bearer = self.get_bearer_token()?;
+        let pairs: Vec<(String, String)> = form
+            .into_iter()
+            .map(|(k, v)| (k.as_ref().to_owned(), v.as_ref().to_owned()))
+            .collect();
+        self.http_client
+            .post(url)
+            .bearer_auth(bearer)
+            .header("accept", "application/json")
+            .form(&pairs)
+            .send()
+            .await
+            .map_err(Error::NetworkError)?
+            .json::<T>()
             .await
             .map_err(Error::NetworkError)
     }
@@ -178,6 +217,287 @@ impl Accounts for TradierRestClient {
         let raw_response = self.make_service_call(url, bearer_auth).await?;
         raw_response
             .json::<GetAccountOrdersResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+}
+
+#[async_trait::async_trait]
+impl MarketData for TradierRestClient {
+    async fn get_quotes(
+        &self,
+        symbols: &Symbols,
+        greeks: Option<Greeks>,
+    ) -> Result<GetQuotesResponse> {
+        let mut url = self.get_request_url("/v1/markets/quotes")?;
+        {
+            let mut qp = url.query_pairs_mut();
+            qp.append_pair("symbols", &symbols.to_string());
+            if let Some(g) = greeks {
+                qp.append_pair("greeks", &g.to_string());
+            }
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetQuotesResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn post_quotes(
+        &self,
+        symbols: &Symbols,
+        greeks: Option<Greeks>,
+    ) -> Result<GetQuotesResponse> {
+        let url = self.get_request_url("/v1/markets/quotes")?;
+        let mut form: Vec<(&str, String)> = Vec::with_capacity(2);
+        form.push(("symbols", symbols.to_string()));
+        if let Some(g) = greeks {
+            form.push(("greeks", g.to_string()));
+        }
+        self.post_form::<GetQuotesResponse, _, _, _>(url, form)
+            .await
+    }
+
+    async fn get_option_chains(
+        &self,
+        symbol: &Symbol,
+        expiration: &NaiveDate,
+        greeks: Option<Greeks>,
+    ) -> Result<GetOptionChainsResponse> {
+        let mut url = self.get_request_url("/v1/markets/options/chains")?;
+        {
+            let mut qp = url.query_pairs_mut();
+            qp.append_pair("symbol", &symbol.to_string());
+            qp.append_pair("expiration", &format_naive_date(expiration));
+            if let Some(g) = greeks {
+                qp.append_pair("greeks", &g.to_string());
+            }
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetOptionChainsResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn get_option_strikes(
+        &self,
+        symbol: &Symbol,
+        expiration: &NaiveDate,
+    ) -> Result<GetOptionStrikesResponse> {
+        let mut url = self.get_request_url("/v1/markets/options/strikes")?;
+        url.query_pairs_mut()
+            .append_pair("symbol", &symbol.to_string())
+            .append_pair("expiration", &format_naive_date(expiration));
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetOptionStrikesResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn get_option_expirations(
+        &self,
+        symbol: &Symbol,
+        include_all_roots: Option<IncludeAllRoots>,
+        strikes: Option<IncludeStrikes>,
+    ) -> Result<GetOptionExpirationsResponse> {
+        let mut url = self.get_request_url("/v1/markets/options/expirations")?;
+        {
+            let mut qp = url.query_pairs_mut();
+            qp.append_pair("symbol", &symbol.to_string());
+            if let Some(v) = include_all_roots {
+                qp.append_pair("includeAllRoots", &v.to_string());
+            }
+            if let Some(v) = strikes {
+                qp.append_pair("strikes", &v.to_string());
+            }
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetOptionExpirationsResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn lookup_option_symbols(
+        &self,
+        underlying: &Symbol,
+    ) -> Result<LookupOptionSymbolsResponse> {
+        let mut url = self.get_request_url("/v1/markets/options/lookup")?;
+        url.query_pairs_mut()
+            .append_pair("underlying", &underlying.to_string());
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<LookupOptionSymbolsResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn get_historical_quotes(
+        &self,
+        symbol: &Symbol,
+        interval: Option<HistoryInterval>,
+        start: Option<&NaiveDate>,
+        end: Option<&NaiveDate>,
+        session_filter: Option<SessionFilter>,
+    ) -> Result<GetHistoricalQuotesResponse> {
+        let mut url = self.get_request_url("/v1/markets/history")?;
+        {
+            let mut qp = url.query_pairs_mut();
+            qp.append_pair("symbol", &symbol.to_string());
+            if let Some(i) = interval {
+                qp.append_pair("interval", &i.to_string());
+            }
+            if let Some(s) = start {
+                qp.append_pair("start", &format_naive_date(s));
+            }
+            if let Some(e) = end {
+                qp.append_pair("end", &format_naive_date(e));
+            }
+            if let Some(f) = session_filter {
+                qp.append_pair("session_filter", &f.to_string());
+            }
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetHistoricalQuotesResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn get_time_and_sales(
+        &self,
+        symbol: &Symbol,
+        interval: Option<TimeSalesInterval>,
+        start: Option<&DateTime<Utc>>,
+        end: Option<&DateTime<Utc>>,
+        session_filter: Option<SessionFilter>,
+    ) -> Result<GetTimeAndSalesResponse> {
+        let mut url = self.get_request_url("/v1/markets/timesales")?;
+        {
+            let mut qp = url.query_pairs_mut();
+            qp.append_pair("symbol", &symbol.to_string());
+            if let Some(i) = interval {
+                qp.append_pair("interval", &i.to_string());
+            }
+            if let Some(s) = start {
+                qp.append_pair("start", &format_timesales_datetime(s));
+            }
+            if let Some(e) = end {
+                qp.append_pair("end", &format_timesales_datetime(e));
+            }
+            if let Some(f) = session_filter {
+                qp.append_pair("session_filter", &f.to_string());
+            }
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetTimeAndSalesResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn get_etb_securities(&self) -> Result<GetEtbSecuritiesResponse> {
+        let url = self.get_request_url("/v1/markets/etb")?;
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetEtbSecuritiesResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn get_clock(&self, delayed: Option<DelayedFlag>) -> Result<GetClockResponse> {
+        let mut url = self.get_request_url("/v1/markets/clock")?;
+        if let Some(d) = delayed {
+            url.query_pairs_mut().append_pair("delayed", &d.to_string());
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetClockResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn get_calendar(
+        &self,
+        month: Option<CalendarMonth>,
+        year: Option<CalendarYear>,
+    ) -> Result<GetCalendarResponse> {
+        let mut url = self.get_request_url("/v1/markets/calendar")?;
+        {
+            let mut qp = url.query_pairs_mut();
+            if let Some(m) = month {
+                qp.append_pair("month", &m.to_string());
+            }
+            if let Some(y) = year {
+                qp.append_pair("year", &y.to_string());
+            }
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<GetCalendarResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn search_companies(
+        &self,
+        q: &str,
+        indexes: Option<IndexesFlag>,
+    ) -> Result<SearchCompaniesResponse> {
+        let mut url = self.get_request_url("/v1/markets/search")?;
+        {
+            let mut qp = url.query_pairs_mut();
+            qp.append_pair("q", q);
+            if let Some(i) = indexes {
+                qp.append_pair("indexes", &i.to_string());
+            }
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<SearchCompaniesResponse>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+
+    async fn lookup_symbol(
+        &self,
+        q: &str,
+        exchanges: Option<&Exchanges>,
+        types: Option<&SecurityTypes>,
+    ) -> Result<LookupSymbolResponse> {
+        let mut url = self.get_request_url("/v1/markets/lookup")?;
+        {
+            let mut qp = url.query_pairs_mut();
+            qp.append_pair("q", q);
+            if let Some(ex) = exchanges {
+                if !ex.is_empty() {
+                    qp.append_pair("exchanges", &ex.to_string());
+                }
+            }
+            if let Some(t) = types {
+                if !t.is_empty() {
+                    qp.append_pair("types", &t.to_string());
+                }
+            }
+        }
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<LookupSymbolResponse>()
             .await
             .map_err(Error::NetworkError)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,10 @@ pub type Result<T> = core::result::Result<T, Error>;
 pub enum Error {
     #[error("Unable to parse the string {0} into an AccountId, must be valid ASCII")]
     AccountIdParseError(String),
+
+    /// Error while parsing a market-data domain value (symbol, month, interval, ...).
+    #[error("Market data parse error: {0}")]
+    MarketDataParseError(String),
     /// Error when parsing a URL fails.
     ///
     /// # Source

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ mod watchlists;
 pub mod types {
     pub use crate::accounts::types::*;
     pub use crate::common::SortOrder;
+    pub use crate::market_data::types::*;
     pub use crate::user::types::*;
     pub use crate::utils::OneOrMany;
 }
@@ -30,6 +31,7 @@ pub mod blocking {
     pub use super::client::blocking::BlockingTradierRestClient as Client;
     pub mod operation {
         pub use crate::accounts::api::blocking::Accounts;
+        pub use crate::market_data::api::blocking::MarketData;
         pub use crate::user::api::blocking::User;
     }
 }
@@ -38,6 +40,7 @@ pub mod non_blocking {
     pub use super::client::non_blocking::TradierRestClient as Client;
     pub mod operation {
         pub use crate::accounts::api::non_blocking::Accounts;
+        pub use crate::market_data::api::non_blocking::MarketData;
         pub use crate::user::api::non_blocking::User;
     }
 }

--- a/src/market_data/api.rs
+++ b/src/market_data/api.rs
@@ -1,0 +1,291 @@
+//! Traits exposing the Market Data REST endpoints, in both blocking and
+//! non-blocking flavors.
+//!
+//! Upstream documentation: <https://documentation.tradier.com/brokerage-api/markets/>.
+
+use chrono::{DateTime, NaiveDate, Utc};
+
+use crate::market_data::types::{
+    CalendarMonth, CalendarYear, DelayedFlag, Exchanges, GetCalendarResponse, GetClockResponse,
+    GetEtbSecuritiesResponse, GetHistoricalQuotesResponse, GetOptionChainsResponse,
+    GetOptionExpirationsResponse, GetOptionStrikesResponse, GetQuotesResponse,
+    GetTimeAndSalesResponse, Greeks, HistoryInterval, IncludeAllRoots, IncludeStrikes,
+    IndexesFlag, LookupOptionSymbolsResponse, LookupSymbolResponse, SearchCompaniesResponse,
+    SecurityTypes, SessionFilter, Symbol, Symbols, TimeSalesInterval,
+};
+use crate::{error::Result, utils::Sealed};
+
+pub mod non_blocking {
+    use super::*;
+
+    /// The non-blocking (async) surface of the Tradier Market Data REST API.
+    #[async_trait::async_trait]
+    pub trait MarketData: Sealed {
+        /// `GET /v1/markets/quotes` — retrieve quotes for one or more symbols.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_quotes(
+            &self,
+            symbols: &Symbols,
+            greeks: Option<Greeks>,
+        ) -> Result<GetQuotesResponse>;
+
+        /// `POST /v1/markets/quotes` — form-encoded variant for large symbol lists.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn post_quotes(
+            &self,
+            symbols: &Symbols,
+            greeks: Option<Greeks>,
+        ) -> Result<GetQuotesResponse>;
+
+        /// `GET /v1/markets/options/chains` — option chain for a symbol + expiration.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_option_chains(
+            &self,
+            symbol: &Symbol,
+            expiration: &NaiveDate,
+            greeks: Option<Greeks>,
+        ) -> Result<GetOptionChainsResponse>;
+
+        /// `GET /v1/markets/options/strikes` — list of strikes for a given expiration.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_option_strikes(
+            &self,
+            symbol: &Symbol,
+            expiration: &NaiveDate,
+        ) -> Result<GetOptionStrikesResponse>;
+
+        /// `GET /v1/markets/options/expirations` — list of available expirations.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_option_expirations(
+            &self,
+            symbol: &Symbol,
+            include_all_roots: Option<IncludeAllRoots>,
+            strikes: Option<IncludeStrikes>,
+        ) -> Result<GetOptionExpirationsResponse>;
+
+        /// `GET /v1/markets/options/lookup` — list option root symbols for an underlying.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn lookup_option_symbols(
+            &self,
+            underlying: &Symbol,
+        ) -> Result<LookupOptionSymbolsResponse>;
+
+        /// `GET /v1/markets/history` — historical OHLCV bars.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_historical_quotes(
+            &self,
+            symbol: &Symbol,
+            interval: Option<HistoryInterval>,
+            start: Option<&NaiveDate>,
+            end: Option<&NaiveDate>,
+            session_filter: Option<SessionFilter>,
+        ) -> Result<GetHistoricalQuotesResponse>;
+
+        /// `GET /v1/markets/timesales` — intraday time-and-sales data.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_time_and_sales(
+            &self,
+            symbol: &Symbol,
+            interval: Option<TimeSalesInterval>,
+            start: Option<&DateTime<Utc>>,
+            end: Option<&DateTime<Utc>>,
+            session_filter: Option<SessionFilter>,
+        ) -> Result<GetTimeAndSalesResponse>;
+
+        /// `GET /v1/markets/etb` — easy-to-borrow securities list.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_etb_securities(&self) -> Result<GetEtbSecuritiesResponse>;
+
+        /// `GET /v1/markets/clock` — market clock state.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_clock(&self, delayed: Option<DelayedFlag>) -> Result<GetClockResponse>;
+
+        /// `GET /v1/markets/calendar` — market calendar for a given month.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_calendar(
+            &self,
+            month: Option<CalendarMonth>,
+            year: Option<CalendarYear>,
+        ) -> Result<GetCalendarResponse>;
+
+        /// `GET /v1/markets/search` — search for companies.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn search_companies(
+            &self,
+            q: &str,
+            indexes: Option<IndexesFlag>,
+        ) -> Result<SearchCompaniesResponse>;
+
+        /// `GET /v1/markets/lookup` — look up a symbol.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn lookup_symbol(
+            &self,
+            q: &str,
+            exchanges: Option<&Exchanges>,
+            types: Option<&SecurityTypes>,
+        ) -> Result<LookupSymbolResponse>;
+    }
+}
+
+pub mod blocking {
+    use super::*;
+
+    /// The blocking surface of the Tradier Market Data REST API.
+    pub trait MarketData: Sealed {
+        /// See [`super::non_blocking::MarketData::get_quotes`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_quotes`].
+        fn get_quotes(
+            &self,
+            symbols: &Symbols,
+            greeks: Option<Greeks>,
+        ) -> Result<GetQuotesResponse>;
+
+        /// See [`super::non_blocking::MarketData::post_quotes`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::post_quotes`].
+        fn post_quotes(
+            &self,
+            symbols: &Symbols,
+            greeks: Option<Greeks>,
+        ) -> Result<GetQuotesResponse>;
+
+        /// See [`super::non_blocking::MarketData::get_option_chains`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_option_chains`].
+        fn get_option_chains(
+            &self,
+            symbol: &Symbol,
+            expiration: &NaiveDate,
+            greeks: Option<Greeks>,
+        ) -> Result<GetOptionChainsResponse>;
+
+        /// See [`super::non_blocking::MarketData::get_option_strikes`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_option_strikes`].
+        fn get_option_strikes(
+            &self,
+            symbol: &Symbol,
+            expiration: &NaiveDate,
+        ) -> Result<GetOptionStrikesResponse>;
+
+        /// See [`super::non_blocking::MarketData::get_option_expirations`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_option_expirations`].
+        fn get_option_expirations(
+            &self,
+            symbol: &Symbol,
+            include_all_roots: Option<IncludeAllRoots>,
+            strikes: Option<IncludeStrikes>,
+        ) -> Result<GetOptionExpirationsResponse>;
+
+        /// See [`super::non_blocking::MarketData::lookup_option_symbols`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::lookup_option_symbols`].
+        fn lookup_option_symbols(
+            &self,
+            underlying: &Symbol,
+        ) -> Result<LookupOptionSymbolsResponse>;
+
+        /// See [`super::non_blocking::MarketData::get_historical_quotes`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_historical_quotes`].
+        fn get_historical_quotes(
+            &self,
+            symbol: &Symbol,
+            interval: Option<HistoryInterval>,
+            start: Option<&NaiveDate>,
+            end: Option<&NaiveDate>,
+            session_filter: Option<SessionFilter>,
+        ) -> Result<GetHistoricalQuotesResponse>;
+
+        /// See [`super::non_blocking::MarketData::get_time_and_sales`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_time_and_sales`].
+        fn get_time_and_sales(
+            &self,
+            symbol: &Symbol,
+            interval: Option<TimeSalesInterval>,
+            start: Option<&DateTime<Utc>>,
+            end: Option<&DateTime<Utc>>,
+            session_filter: Option<SessionFilter>,
+        ) -> Result<GetTimeAndSalesResponse>;
+
+        /// See [`super::non_blocking::MarketData::get_etb_securities`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_etb_securities`].
+        fn get_etb_securities(&self) -> Result<GetEtbSecuritiesResponse>;
+
+        /// See [`super::non_blocking::MarketData::get_clock`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_clock`].
+        fn get_clock(&self, delayed: Option<DelayedFlag>) -> Result<GetClockResponse>;
+
+        /// See [`super::non_blocking::MarketData::get_calendar`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::get_calendar`].
+        fn get_calendar(
+            &self,
+            month: Option<CalendarMonth>,
+            year: Option<CalendarYear>,
+        ) -> Result<GetCalendarResponse>;
+
+        /// See [`super::non_blocking::MarketData::search_companies`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::search_companies`].
+        fn search_companies(
+            &self,
+            q: &str,
+            indexes: Option<IndexesFlag>,
+        ) -> Result<SearchCompaniesResponse>;
+
+        /// See [`super::non_blocking::MarketData::lookup_symbol`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::MarketData::lookup_symbol`].
+        fn lookup_symbol(
+            &self,
+            q: &str,
+            exchanges: Option<&Exchanges>,
+            types: Option<&SecurityTypes>,
+        ) -> Result<LookupSymbolResponse>;
+    }
+}

--- a/src/market_data/api.rs
+++ b/src/market_data/api.rs
@@ -9,9 +9,9 @@ use crate::market_data::types::{
     CalendarMonth, CalendarYear, DelayedFlag, Exchanges, GetCalendarResponse, GetClockResponse,
     GetEtbSecuritiesResponse, GetHistoricalQuotesResponse, GetOptionChainsResponse,
     GetOptionExpirationsResponse, GetOptionStrikesResponse, GetQuotesResponse,
-    GetTimeAndSalesResponse, Greeks, HistoryInterval, IncludeAllRoots, IncludeStrikes,
-    IndexesFlag, LookupOptionSymbolsResponse, LookupSymbolResponse, SearchCompaniesResponse,
-    SecurityTypes, SessionFilter, Symbol, Symbols, TimeSalesInterval,
+    GetTimeAndSalesResponse, Greeks, HistoryInterval, IncludeAllRoots, IncludeStrikes, IndexesFlag,
+    LookupOptionSymbolsResponse, LookupSymbolResponse, SearchCompaniesResponse, SecurityTypes,
+    SessionFilter, Symbol, Symbols, TimeSalesInterval,
 };
 use crate::{error::Result, utils::Sealed};
 
@@ -214,10 +214,8 @@ pub mod blocking {
         ///
         /// # Errors
         /// See [`super::non_blocking::MarketData::lookup_option_symbols`].
-        fn lookup_option_symbols(
-            &self,
-            underlying: &Symbol,
-        ) -> Result<LookupOptionSymbolsResponse>;
+        fn lookup_option_symbols(&self, underlying: &Symbol)
+            -> Result<LookupOptionSymbolsResponse>;
 
         /// See [`super::non_blocking::MarketData::get_historical_quotes`].
         ///

--- a/src/market_data/get_calendar_schema.json
+++ b/src/market_data/get_calendar_schema.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-market-calendar.json",
+    "title": "GetCalendar response",
+    "type": "object",
+    "required": ["calendar"],
+    "additionalProperties": false,
+    "properties": {
+        "calendar": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["month", "year", "days"],
+            "properties": {
+                "month": { "type": "integer", "minimum": 1, "maximum": 12 },
+                "year": { "type": "integer", "minimum": 0 },
+                "days": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["day"],
+                    "properties": {
+                        "day": {
+                            "type": "array",
+                            "items": { "$ref": "#/$defs/CalendarDay" }
+                        }
+                    }
+                }
+            }
+        }
+    },
+    "$defs": {
+        "CalendarDay": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["date", "status", "description"],
+            "properties": {
+                "date": { "type": "string" },
+                "status": { "type": "string" },
+                "description": { "type": "string" },
+                "premarket": { "$ref": "#/$defs/Window" },
+                "open": { "$ref": "#/$defs/Window" },
+                "postmarket": { "$ref": "#/$defs/Window" }
+            }
+        },
+        "Window": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["start", "end"],
+            "properties": {
+                "start": { "type": "string" },
+                "end": { "type": "string" }
+            }
+        }
+    }
+}

--- a/src/market_data/get_history_schema.json
+++ b/src/market_data/get_history_schema.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-market-history.json",
+    "title": "GetHistoricalQuotes response",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "history": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["day"],
+            "properties": {
+                "day": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["date", "open", "high", "low", "close", "volume"],
+                        "properties": {
+                            "date": { "type": "string" },
+                            "open": { "type": "number" },
+                            "high": { "type": "number" },
+                            "low": { "type": "number" },
+                            "close": { "type": "number" },
+                            "volume": { "type": "integer", "minimum": 0 }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/market_data/get_lookup_schema.json
+++ b/src/market_data/get_lookup_schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-market-lookup.json",
+    "title": "LookupSymbol response",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "securities": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["security"],
+            "properties": {
+                "security": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["symbol", "exchange", "type", "description"],
+                        "properties": {
+                            "symbol": { "type": "string" },
+                            "exchange": { "type": "string" },
+                            "type": { "type": "string" },
+                            "description": { "type": "string" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/market_data/get_option_chains_schema.json
+++ b/src/market_data/get_option_chains_schema.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-market-option-chains.json",
+    "title": "GetOptionChains response",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "options": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["option"],
+            "properties": {
+                "option": {
+                    "type": "array",
+                    "items": { "type": "object" }
+                }
+            }
+        }
+    }
+}

--- a/src/market_data/get_option_expirations_schema.json
+++ b/src/market_data/get_option_expirations_schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-market-option-expirations.json",
+    "title": "GetOptionExpirations response",
+    "type": "object",
+    "required": ["expirations"],
+    "additionalProperties": false,
+    "properties": {
+        "expirations": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "date": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                },
+                "expiration": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/ExpirationEntry" }
+                }
+            }
+        }
+    },
+    "$defs": {
+        "ExpirationEntry": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["date"],
+            "properties": {
+                "date": { "type": "string" },
+                "contract_size": { "type": "integer", "minimum": 0 },
+                "expiration_type": { "type": "string" },
+                "strikes": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["strike"],
+                    "properties": {
+                        "strike": {
+                            "type": "array",
+                            "items": { "type": "number" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/market_data/get_quotes_schema.json
+++ b/src/market_data/get_quotes_schema.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-market-quotes.json",
+    "title": "GetQuotes response",
+    "type": "object",
+    "required": ["quotes"],
+    "additionalProperties": false,
+    "properties": {
+        "quotes": { "$ref": "#/$defs/QuotesPayload" }
+    },
+    "$defs": {
+        "QuotesPayload": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "quote": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Quote" }
+                },
+                "unmatched_symbols": { "$ref": "#/$defs/UnmatchedSymbols" }
+            }
+        },
+        "UnmatchedSymbols": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["symbol"],
+            "properties": {
+                "symbol": { "type": "array", "items": { "type": "string" } }
+            }
+        },
+        "Quote": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["symbol", "description", "exch", "type"],
+            "properties": {
+                "symbol": { "type": "string" },
+                "description": { "type": "string" },
+                "exch": { "type": "string" },
+                "type": { "type": "string" },
+                "last": { "type": "number" },
+                "change": { "type": "number" },
+                "volume": { "type": "integer", "minimum": 0 },
+                "open": { "type": "number" },
+                "high": { "type": "number" },
+                "low": { "type": "number" },
+                "close": { "type": "number" },
+                "bid": { "type": "number" },
+                "ask": { "type": "number" },
+                "change_percentage": { "type": "number" },
+                "average_volume": { "type": "integer", "minimum": 0 },
+                "last_volume": { "type": "integer", "minimum": 0 },
+                "trade_date": { "type": "integer" },
+                "prevclose": { "type": "number" },
+                "week_52_high": { "type": "number" },
+                "week_52_low": { "type": "number" },
+                "bidsize": { "type": "integer", "minimum": 0 },
+                "bidexch": { "type": "string" },
+                "bid_date": { "type": "integer" },
+                "asksize": { "type": "integer", "minimum": 0 },
+                "askexch": { "type": "string" },
+                "ask_date": { "type": "integer" },
+                "root_symbols": { "type": "string" },
+                "underlying": { "type": "string" },
+                "strike": { "type": "number" },
+                "open_interest": { "type": "integer", "minimum": 0 },
+                "contract_size": { "type": "integer", "minimum": 0 },
+                "expiration_date": { "type": "string" },
+                "expiration_type": { "type": "string" },
+                "option_type": { "type": "string" },
+                "root_symbol": { "type": "string" },
+                "greeks": { "$ref": "#/$defs/Greeks" }
+            }
+        },
+        "Greeks": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "delta": { "type": "number" },
+                "gamma": { "type": "number" },
+                "theta": { "type": "number" },
+                "vega": { "type": "number" },
+                "rho": { "type": "number" },
+                "phi": { "type": "number" },
+                "bid_iv": { "type": "number" },
+                "mid_iv": { "type": "number" },
+                "ask_iv": { "type": "number" },
+                "smv_vol": { "type": "number" },
+                "updated_at": { "type": "string" }
+            }
+        }
+    }
+}

--- a/src/market_data/get_timesales_schema.json
+++ b/src/market_data/get_timesales_schema.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-market-timesales.json",
+    "title": "GetTimeAndSales response",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "series": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["data"],
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": ["time", "timestamp", "price", "open", "high", "low", "close", "volume"],
+                        "properties": {
+                            "time": { "type": "string" },
+                            "timestamp": { "type": "integer" },
+                            "price": { "type": "number" },
+                            "open": { "type": "number" },
+                            "high": { "type": "number" },
+                            "low": { "type": "number" },
+                            "close": { "type": "number" },
+                            "volume": { "type": "integer", "minimum": 0 },
+                            "vwap": { "type": "number" }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/market_data/mod.rs
+++ b/src/market_data/mod.rs
@@ -1,1 +1,11 @@
+//! Market Data REST endpoints.
+//!
+//! Provides typed bindings for the Tradier `markets/*` REST surface,
+//! exposed both as blocking and non-blocking traits.
+//!
+//! Upstream docs: <https://documentation.tradier.com/brokerage-api/markets/>.
 
+pub mod api;
+#[cfg(test)]
+pub(crate) mod test_support;
+pub mod types;

--- a/src/market_data/test_support.rs
+++ b/src/market_data/test_support.rs
@@ -1,0 +1,537 @@
+//! Test-only wire types for market-data fixtures.
+//!
+//! These `Serialize` / `proptest_derive::Arbitrary` structs mirror the
+//! deserialized types in `types.rs` but go the other way: they produce JSON
+//! we can feed back into the real deserializers and into JSON Schema
+//! validators. They are gated to `cfg(test)` via the parent module.
+
+use chrono::NaiveDate;
+use proptest::{prelude::Strategy, strategy::Just};
+use serde::Serialize;
+
+/// A [`NaiveDate`] strategy that yields only valid wall-clock dates.
+fn arb_naive_date() -> impl Strategy<Value = NaiveDate> {
+    (1970i32..=2100, 1u32..=12, 1u32..=28)
+        .prop_flat_map(|(y, m, d)| Just(NaiveDate::from_ymd_opt(y, m, d).unwrap()))
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct NaiveDateWire(#[proptest(strategy = "arb_naive_date()")] NaiveDate);
+
+// -----------------------------------------------------------------------------
+// Quotes wire types
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetQuotesResponseWire {
+    pub quotes: QuotesPayloadWire,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct QuotesPayloadWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub quote: Option<Vec<QuoteWire>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub unmatched_symbols: Option<UnmatchedSymbolsWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct UnmatchedSymbolsWire {
+    pub symbol: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct QuoteWire {
+    pub symbol: String,
+    pub description: String,
+    pub exch: String,
+    #[serde(rename = "type")]
+    pub quote_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volume: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub high: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub low: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub close: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bid: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ask: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub change_percentage: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub average_volume: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_volume: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trade_date: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prevclose: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub week_52_high: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub week_52_low: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bidsize: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bidexch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bid_date: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asksize: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub askexch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ask_date: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_symbols: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub underlying: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strike: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open_interest: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub option_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub root_symbol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub greeks: Option<GreeksDataWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GreeksDataWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub delta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gamma: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub theta: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vega: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rho: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phi: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bid_iv: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mid_iv: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ask_iv: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub smv_vol: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
+// -----------------------------------------------------------------------------
+// Option chains, strikes, expirations, lookup
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetOptionChainsResponseWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub options: Option<OptionChainsPayloadWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct OptionChainsPayloadWire {
+    pub option: Vec<QuoteWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetOptionStrikesResponseWire {
+    pub strikes: OptionStrikesPayloadWire,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct OptionStrikesPayloadWire {
+    pub strike: Vec<f64>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetOptionExpirationsResponseWire {
+    pub expirations: OptionExpirationsPayloadWire,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct OptionExpirationsPayloadWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub date: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration: Option<Vec<ExpirationEntryWire>>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct ExpirationEntryWire {
+    pub date: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contract_size: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiration_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strikes: Option<ExpirationStrikesWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct ExpirationStrikesWire {
+    pub strike: Vec<f64>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct LookupOptionSymbolsResponseWire {
+    pub symbols: Vec<LookupOptionSymbolsRootWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct LookupOptionSymbolsRootWire {
+    #[serde(rename = "rootSymbol")]
+    pub root_symbol: String,
+    pub options: Vec<String>,
+}
+
+// -----------------------------------------------------------------------------
+// History & timesales
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetHistoricalQuotesResponseWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history: Option<HistoryPayloadWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct HistoryPayloadWire {
+    pub day: Vec<HistoryDayWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct HistoryDayWire {
+    pub date: NaiveDateWire,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    pub volume: u64,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetTimeAndSalesResponseWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub series: Option<TimeSalesPayloadWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct TimeSalesPayloadWire {
+    pub data: Vec<TimeSalesEntryWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct TimeSalesEntryWire {
+    pub time: String,
+    pub timestamp: i64,
+    pub price: f64,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    pub volume: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub vwap: Option<f64>,
+}
+
+// -----------------------------------------------------------------------------
+// ETB / Clock / Calendar
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetEtbSecuritiesResponseWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub securities: Option<EtbSecuritiesWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct EtbSecuritiesWire {
+    pub security: Vec<EtbSecurityWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct EtbSecurityWire {
+    pub symbol: String,
+    pub exchange: String,
+    #[serde(rename = "type")]
+    pub security_type: String,
+    pub description: String,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetClockResponseWire {
+    pub clock: MarketClockWire,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct MarketClockWire {
+    pub date: String,
+    pub description: String,
+    pub state: String,
+    pub timestamp: i64,
+    pub next_change: String,
+    pub next_state: String,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct GetCalendarResponseWire {
+    pub calendar: MarketCalendarWire,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct MarketCalendarWire {
+    #[proptest(strategy = "1u32..=12")]
+    pub month: u32,
+    #[proptest(strategy = "1970u32..=2100")]
+    pub year: u32,
+    pub days: CalendarDaysWire,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct CalendarDaysWire {
+    pub day: Vec<CalendarDayWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct CalendarDayWire {
+    pub date: NaiveDateWire,
+    pub status: String,
+    pub description: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub premarket: Option<CalendarWindowWire>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub open: Option<CalendarWindowWire>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub postmarket: Option<CalendarWindowWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct CalendarWindowWire {
+    pub start: String,
+    pub end: String,
+}
+
+// -----------------------------------------------------------------------------
+// Search / Lookup
+// -----------------------------------------------------------------------------
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct SearchCompaniesResponseWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub securities: Option<SearchSecuritiesWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct SearchSecuritiesWire {
+    pub security: Vec<SearchSecurityWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct SearchSecurityWire {
+    pub symbol: String,
+    pub exchange: String,
+    #[serde(rename = "type")]
+    pub security_type: String,
+    pub description: String,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct LookupSymbolResponseWire {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub securities: Option<LookupSecuritiesWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct LookupSecuritiesWire {
+    pub security: Vec<LookupSecurityWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct LookupSecurityWire {
+    pub symbol: String,
+    pub exchange: String,
+    #[serde(rename = "type")]
+    pub security_type: String,
+    pub description: String,
+}
+
+// -----------------------------------------------------------------------------
+// Schema validation tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+    use serde_json::{json, Value};
+    use std::fs::OpenOptions;
+
+    static QUOTES_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/market_data/get_quotes_schema.json"
+    );
+    static CHAINS_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/market_data/get_option_chains_schema.json"
+    );
+    static EXPIRATIONS_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/market_data/get_option_expirations_schema.json"
+    );
+    static HISTORY_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/market_data/get_history_schema.json"
+    );
+    static TIMESALES_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/market_data/get_timesales_schema.json"
+    );
+    static CALENDAR_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/market_data/get_calendar_schema.json"
+    );
+    static LOOKUP_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/market_data/get_lookup_schema.json"
+    );
+
+    fn load_validator(path: &str) -> jsonschema::Validator {
+        let reader = OpenOptions::new()
+            .read(true)
+            .open(path)
+            .expect("schema file to exist");
+        let reader = std::io::BufReader::new(reader);
+        let schema: Value = serde_json::from_reader(reader).expect("schema JSON");
+        jsonschema::validator_for(&schema).expect("validator")
+    }
+
+    #[test]
+    fn empty_quotes_object_should_fail_schema_validation() {
+        let validator = load_validator(QUOTES_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_chains_object_should_fail_schema_validation() {
+        let validator = load_validator(CHAINS_PATH);
+        assert!(!validator.is_valid(&json!({ "foo": 1 })));
+    }
+
+    #[test]
+    fn empty_expirations_object_should_fail_schema_validation() {
+        let validator = load_validator(EXPIRATIONS_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_history_object_should_fail_schema_validation() {
+        let validator = load_validator(HISTORY_PATH);
+        assert!(!validator.is_valid(&json!({ "foo": 1 })));
+    }
+
+    #[test]
+    fn empty_timesales_object_should_fail_schema_validation() {
+        let validator = load_validator(TIMESALES_PATH);
+        assert!(!validator.is_valid(&json!({ "foo": 1 })));
+    }
+
+    #[test]
+    fn empty_calendar_object_should_fail_schema_validation() {
+        let validator = load_validator(CALENDAR_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_lookup_object_should_fail_schema_validation() {
+        let validator = load_validator(LOOKUP_PATH);
+        assert!(!validator.is_valid(&json!({ "foo": 1 })));
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        #[test]
+        fn serialized_quotes_wire_should_conform_to_schema(
+            wire in any::<GetQuotesResponseWire>()
+        ) {
+            let validator = load_validator(QUOTES_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_chains_wire_should_conform_to_schema(
+            wire in any::<GetOptionChainsResponseWire>()
+        ) {
+            let validator = load_validator(CHAINS_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_expirations_wire_should_conform_to_schema(
+            wire in any::<GetOptionExpirationsResponseWire>()
+        ) {
+            let validator = load_validator(EXPIRATIONS_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_history_wire_should_conform_to_schema(
+            wire in any::<GetHistoricalQuotesResponseWire>()
+        ) {
+            let validator = load_validator(HISTORY_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_timesales_wire_should_conform_to_schema(
+            wire in any::<GetTimeAndSalesResponseWire>()
+        ) {
+            let validator = load_validator(TIMESALES_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_calendar_wire_should_conform_to_schema(
+            wire in any::<GetCalendarResponseWire>()
+        ) {
+            let validator = load_validator(CALENDAR_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_lookup_wire_should_conform_to_schema(
+            wire in any::<LookupSymbolResponseWire>()
+        ) {
+            let validator = load_validator(LOOKUP_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+    }
+}

--- a/src/market_data/types.rs
+++ b/src/market_data/types.rs
@@ -1,0 +1,1078 @@
+//! Request and response types for the Tradier Market Data REST endpoints.
+//!
+//! See upstream documentation at
+//! <https://documentation.tradier.com/brokerage-api/markets/>.
+
+use std::str::FromStr;
+
+use chrono::{DateTime, NaiveDate, Utc};
+use serde::Deserialize;
+
+use crate::utils::OneOrMany;
+
+// -----------------------------------------------------------------------------
+// Shared newtypes & enums
+// -----------------------------------------------------------------------------
+
+/// A ticker symbol (equity, option, index, etc.).
+///
+/// Tradier symbols are ASCII printable strings; this wrapper validates the
+/// input and rejects empty / blank values.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Symbol(String);
+
+impl Symbol {
+    /// Returns the inner string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for Symbol {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.trim().is_empty() {
+            Err(crate::Error::MarketDataParseError(format!(
+                "invalid symbol: '{s}' must not be empty or blank"
+            )))
+        } else if s.chars().all(|c| (0x20u8..0x7fu8).contains(&(c as u8))) {
+            Ok(Self(s.to_string()))
+        } else {
+            Err(crate::Error::MarketDataParseError(format!(
+                "invalid symbol: '{s}' must be printable ASCII"
+            )))
+        }
+    }
+}
+
+impl std::fmt::Display for Symbol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Comma-separated collection of [`Symbol`]s used by quote endpoints.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Symbols(Vec<Symbol>);
+
+impl Symbols {
+    /// Creates a new [`Symbols`] from an iterator of [`Symbol`].
+    #[must_use]
+    pub fn new(symbols: impl IntoIterator<Item = Symbol>) -> Self {
+        Self(symbols.into_iter().collect())
+    }
+
+    /// Returns the inner slice of [`Symbol`] values.
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[Symbol] {
+        &self.0
+    }
+
+    /// Returns `true` if no symbols have been added.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for Symbols {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut first = true;
+        for s in &self.0 {
+            if !first {
+                f.write_str(",")?;
+            }
+            f.write_str(s.as_str())?;
+            first = false;
+        }
+        Ok(())
+    }
+}
+
+/// Controls whether to include Greeks on option quote responses.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Greeks(bool);
+
+impl Greeks {
+    /// Constructs a new [`Greeks`] flag.
+    #[inline]
+    #[must_use]
+    pub const fn new(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for Greeks {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<bool> for Greeks {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+/// Historical data bar granularity.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum HistoryInterval {
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+impl std::fmt::Display for HistoryInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            HistoryInterval::Daily => "daily",
+            HistoryInterval::Weekly => "weekly",
+            HistoryInterval::Monthly => "monthly",
+        })
+    }
+}
+
+/// Time-and-sales data bar granularity.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum TimeSalesInterval {
+    Tick,
+    OneMinute,
+    FiveMinutes,
+    FifteenMinutes,
+}
+
+impl std::fmt::Display for TimeSalesInterval {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            TimeSalesInterval::Tick => "tick",
+            TimeSalesInterval::OneMinute => "1min",
+            TimeSalesInterval::FiveMinutes => "5min",
+            TimeSalesInterval::FifteenMinutes => "15min",
+        })
+    }
+}
+
+/// Session filter for history / timesales endpoints.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SessionFilter {
+    All,
+    Open,
+}
+
+impl std::fmt::Display for SessionFilter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            SessionFilter::All => "all",
+            SessionFilter::Open => "open",
+        })
+    }
+}
+
+// -----------------------------------------------------------------------------
+// 1 & 2. GET / POST /v1/markets/quotes
+// -----------------------------------------------------------------------------
+
+/// Response to `GET|POST /v1/markets/quotes`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetQuotesResponse {
+    pub quotes: QuotesPayload,
+}
+
+/// Body of the `quotes` response. Tradier returns `quote` as either a single
+/// object, an array, or omits it when all symbols were unmatched.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct QuotesPayload {
+    #[serde(default)]
+    pub quote: Option<OneOrMany<Quote>>,
+    #[serde(default)]
+    pub unmatched_symbols: Option<UnmatchedSymbols>,
+}
+
+/// Wrapper for Tradier's `unmatched_symbols` block which may be a single symbol
+/// string or an array.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct UnmatchedSymbols {
+    pub symbol: OneOrMany<String>,
+}
+
+/// A single quote row returned by the quotes endpoint.
+#[allow(clippy::struct_excessive_bools)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct Quote {
+    pub symbol: String,
+    pub description: String,
+    pub exch: String,
+    #[serde(rename = "type")]
+    pub quote_type: String,
+    #[serde(default)]
+    pub last: Option<f64>,
+    #[serde(default)]
+    pub change: Option<f64>,
+    #[serde(default)]
+    pub volume: Option<u64>,
+    #[serde(default)]
+    pub open: Option<f64>,
+    #[serde(default)]
+    pub high: Option<f64>,
+    #[serde(default)]
+    pub low: Option<f64>,
+    #[serde(default)]
+    pub close: Option<f64>,
+    #[serde(default)]
+    pub bid: Option<f64>,
+    #[serde(default)]
+    pub ask: Option<f64>,
+    #[serde(default)]
+    pub change_percentage: Option<f64>,
+    #[serde(default)]
+    pub average_volume: Option<u64>,
+    #[serde(default)]
+    pub last_volume: Option<u64>,
+    #[serde(default)]
+    pub trade_date: Option<i64>,
+    #[serde(default)]
+    pub prevclose: Option<f64>,
+    #[serde(default)]
+    pub week_52_high: Option<f64>,
+    #[serde(default)]
+    pub week_52_low: Option<f64>,
+    #[serde(default)]
+    pub bidsize: Option<u64>,
+    #[serde(default)]
+    pub bidexch: Option<String>,
+    #[serde(default)]
+    pub bid_date: Option<i64>,
+    #[serde(default)]
+    pub asksize: Option<u64>,
+    #[serde(default)]
+    pub askexch: Option<String>,
+    #[serde(default)]
+    pub ask_date: Option<i64>,
+    #[serde(default)]
+    pub root_symbols: Option<String>,
+    // Option-specific fields
+    #[serde(default)]
+    pub underlying: Option<String>,
+    #[serde(default)]
+    pub strike: Option<f64>,
+    #[serde(default)]
+    pub open_interest: Option<u64>,
+    #[serde(default)]
+    pub contract_size: Option<u64>,
+    #[serde(default)]
+    pub expiration_date: Option<String>,
+    #[serde(default)]
+    pub expiration_type: Option<String>,
+    #[serde(default)]
+    pub option_type: Option<String>,
+    #[serde(default)]
+    pub root_symbol: Option<String>,
+    #[serde(default)]
+    pub greeks: Option<GreeksData>,
+}
+
+/// Greeks block attached to an option quote when requested.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GreeksData {
+    #[serde(default)]
+    pub delta: Option<f64>,
+    #[serde(default)]
+    pub gamma: Option<f64>,
+    #[serde(default)]
+    pub theta: Option<f64>,
+    #[serde(default)]
+    pub vega: Option<f64>,
+    #[serde(default)]
+    pub rho: Option<f64>,
+    #[serde(default)]
+    pub phi: Option<f64>,
+    #[serde(default)]
+    pub bid_iv: Option<f64>,
+    #[serde(default)]
+    pub mid_iv: Option<f64>,
+    #[serde(default)]
+    pub ask_iv: Option<f64>,
+    #[serde(default)]
+    pub smv_vol: Option<f64>,
+    #[serde(default)]
+    pub updated_at: Option<String>,
+}
+
+// -----------------------------------------------------------------------------
+// 3. GET /v1/markets/options/chains
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/options/chains`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetOptionChainsResponse {
+    pub options: Option<OptionChainsPayload>,
+}
+
+/// Body of the options chains response.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct OptionChainsPayload {
+    pub option: OneOrMany<Quote>,
+}
+
+// -----------------------------------------------------------------------------
+// 4. GET /v1/markets/options/strikes
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/options/strikes`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetOptionStrikesResponse {
+    pub strikes: OptionStrikesPayload,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct OptionStrikesPayload {
+    pub strike: OneOrMany<f64>,
+}
+
+// -----------------------------------------------------------------------------
+// 5. GET /v1/markets/options/expirations
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/options/expirations`.
+///
+/// The response shape changes depending on the `strikes` query flag:
+/// - without strikes: `{ "expirations": { "date": ["..."] } }`
+/// - with strikes:    `{ "expirations": { "expiration": [{ "date", "strikes" }] } }`
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetOptionExpirationsResponse {
+    pub expirations: OptionExpirationsPayload,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct OptionExpirationsPayload {
+    #[serde(default)]
+    pub date: Option<OneOrMany<String>>,
+    #[serde(default)]
+    pub expiration: Option<OneOrMany<ExpirationEntry>>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ExpirationEntry {
+    pub date: String,
+    #[serde(default)]
+    pub contract_size: Option<u64>,
+    #[serde(default)]
+    pub expiration_type: Option<String>,
+    #[serde(default)]
+    pub strikes: Option<ExpirationStrikes>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct ExpirationStrikes {
+    pub strike: OneOrMany<f64>,
+}
+
+/// Controls whether expirations endpoint returns all roots.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct IncludeAllRoots(bool);
+
+impl IncludeAllRoots {
+    #[inline]
+    #[must_use]
+    pub const fn new(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for IncludeAllRoots {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<bool> for IncludeAllRoots {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+/// Controls whether expirations endpoint also returns strikes per expiration.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct IncludeStrikes(bool);
+
+impl IncludeStrikes {
+    #[inline]
+    #[must_use]
+    pub const fn new(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for IncludeStrikes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<bool> for IncludeStrikes {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// 6. GET /v1/markets/options/lookup
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/options/lookup`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct LookupOptionSymbolsResponse {
+    pub symbols: OneOrMany<LookupOptionSymbolsRoot>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct LookupOptionSymbolsRoot {
+    #[serde(rename = "rootSymbol")]
+    pub root_symbol: String,
+    pub options: OneOrMany<String>,
+}
+
+// -----------------------------------------------------------------------------
+// 7. GET /v1/markets/history
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/history`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetHistoricalQuotesResponse {
+    pub history: Option<HistoryPayload>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct HistoryPayload {
+    pub day: OneOrMany<HistoryDay>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct HistoryDay {
+    pub date: NaiveDate,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    pub volume: u64,
+}
+
+// -----------------------------------------------------------------------------
+// 8. GET /v1/markets/timesales
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/timesales`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetTimeAndSalesResponse {
+    pub series: Option<TimeSalesPayload>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct TimeSalesPayload {
+    pub data: OneOrMany<TimeSalesEntry>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct TimeSalesEntry {
+    pub time: String,
+    pub timestamp: i64,
+    pub price: f64,
+    pub open: f64,
+    pub high: f64,
+    pub low: f64,
+    pub close: f64,
+    pub volume: u64,
+    #[serde(default)]
+    pub vwap: Option<f64>,
+}
+
+// -----------------------------------------------------------------------------
+// 9. GET /v1/markets/etb
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/etb`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetEtbSecuritiesResponse {
+    pub securities: Option<EtbSecurities>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct EtbSecurities {
+    pub security: OneOrMany<EtbSecurity>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct EtbSecurity {
+    pub symbol: String,
+    pub exchange: String,
+    #[serde(rename = "type")]
+    pub security_type: String,
+    pub description: String,
+}
+
+// -----------------------------------------------------------------------------
+// 10. GET /v1/markets/clock
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/clock`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetClockResponse {
+    pub clock: MarketClock,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct MarketClock {
+    pub date: String,
+    pub description: String,
+    pub state: String,
+    pub timestamp: i64,
+    pub next_change: String,
+    pub next_state: String,
+}
+
+/// Controls whether the clock endpoint returns the delayed state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct DelayedFlag(bool);
+
+impl DelayedFlag {
+    #[inline]
+    #[must_use]
+    pub const fn new(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for DelayedFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<bool> for DelayedFlag {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// 11. GET /v1/markets/calendar
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/calendar`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct GetCalendarResponse {
+    pub calendar: MarketCalendar,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct MarketCalendar {
+    pub month: u32,
+    pub year: u32,
+    pub days: CalendarDays,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct CalendarDays {
+    pub day: OneOrMany<CalendarDay>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct CalendarDay {
+    pub date: NaiveDate,
+    pub status: String,
+    pub description: String,
+    #[serde(default)]
+    pub premarket: Option<CalendarWindow>,
+    #[serde(default)]
+    pub open: Option<CalendarWindow>,
+    #[serde(default)]
+    pub postmarket: Option<CalendarWindow>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct CalendarWindow {
+    pub start: String,
+    pub end: String,
+}
+
+/// Calendar month (1-12) newtype.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CalendarMonth(u32);
+
+impl CalendarMonth {
+    /// Creates a new [`CalendarMonth`], returning an error if the value is not in `1..=12`.
+    ///
+    /// # Errors
+    /// Returns [`crate::Error::MarketDataParseError`] when the value is outside `1..=12`.
+    pub fn new(value: u32) -> crate::Result<Self> {
+        if (1..=12).contains(&value) {
+            Ok(Self(value))
+        } else {
+            Err(crate::Error::MarketDataParseError(format!(
+                "invalid calendar month: {value}, must be in 1..=12"
+            )))
+        }
+    }
+}
+
+impl std::fmt::Display for CalendarMonth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Calendar year (e.g. 2024).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CalendarYear(u32);
+
+impl CalendarYear {
+    #[inline]
+    #[must_use]
+    pub const fn new(value: u32) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for CalendarYear {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// 12. GET /v1/markets/search
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/search`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct SearchCompaniesResponse {
+    pub securities: Option<SearchSecurities>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct SearchSecurities {
+    pub security: OneOrMany<SearchSecurity>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct SearchSecurity {
+    pub symbol: String,
+    pub exchange: String,
+    #[serde(rename = "type")]
+    pub security_type: String,
+    pub description: String,
+}
+
+/// Controls whether the search endpoint restricts to indices.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct IndexesFlag(bool);
+
+impl IndexesFlag {
+    #[inline]
+    #[must_use]
+    pub const fn new(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+impl std::fmt::Display for IndexesFlag {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<bool> for IndexesFlag {
+    fn from(value: bool) -> Self {
+        Self(value)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// 13. GET /v1/markets/lookup
+// -----------------------------------------------------------------------------
+
+/// Response to `GET /v1/markets/lookup`.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct LookupSymbolResponse {
+    pub securities: Option<LookupSecurities>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct LookupSecurities {
+    pub security: OneOrMany<LookupSecurity>,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct LookupSecurity {
+    pub symbol: String,
+    pub exchange: String,
+    #[serde(rename = "type")]
+    pub security_type: String,
+    pub description: String,
+}
+
+/// Comma-separated exchange filter for the lookup endpoint.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Exchanges(Vec<String>);
+
+impl Exchanges {
+    #[must_use]
+    pub fn new(values: impl IntoIterator<Item = String>) -> Self {
+        Self(values.into_iter().collect())
+    }
+
+    /// Returns `true` if no exchanges were provided.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for Exchanges {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0.join(","))
+    }
+}
+
+/// Comma-separated security type filter for the lookup endpoint.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct SecurityTypes(Vec<String>);
+
+impl SecurityTypes {
+    #[must_use]
+    pub fn new(values: impl IntoIterator<Item = String>) -> Self {
+        Self(values.into_iter().collect())
+    }
+
+    /// Returns `true` if no types were provided.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Display for SecurityTypes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0.join(","))
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Helpers to format dates for the wire
+// -----------------------------------------------------------------------------
+
+/// Format a [`NaiveDate`] as `YYYY-MM-DD` for Tradier query strings.
+#[inline]
+#[must_use]
+pub fn format_naive_date(date: &NaiveDate) -> String {
+    date.format("%Y-%m-%d").to_string()
+}
+
+/// Format a [`DateTime<Utc>`] as `YYYY-MM-DD HH:MM` for timesales queries.
+#[inline]
+#[must_use]
+pub fn format_timesales_datetime(dt: &DateTime<Utc>) -> String {
+    dt.format("%Y-%m-%d %H:%M").to_string()
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use chrono::TimeZone;
+    use proptest::prelude::*;
+
+    use crate::market_data::test_support::{
+        GetCalendarResponseWire, GetClockResponseWire, GetEtbSecuritiesResponseWire,
+        GetHistoricalQuotesResponseWire, GetOptionChainsResponseWire,
+        GetOptionExpirationsResponseWire, GetOptionStrikesResponseWire, GetQuotesResponseWire,
+        GetTimeAndSalesResponseWire, LookupOptionSymbolsResponseWire, LookupSymbolResponseWire,
+        SearchCompaniesResponseWire,
+    };
+
+    #[test]
+    fn test_symbol_empty_should_error() {
+        let result: Result<Symbol, _> = "".parse();
+        assert!(result.is_err());
+        let result: Result<Symbol, _> = "   ".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_symbol_valid_should_succeed() {
+        let result: Result<Symbol, _> = "AAPL".parse();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "AAPL");
+    }
+
+    #[test]
+    fn test_symbol_rejects_non_ascii() {
+        let result: Result<Symbol, _> = "BAD\u{80}".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_symbols_display_comma_separated() {
+        let syms = Symbols::new(vec![
+            "AAPL".parse().unwrap(),
+            "MSFT".parse().unwrap(),
+            "GOOG".parse().unwrap(),
+        ]);
+        assert_eq!(syms.to_string(), "AAPL,MSFT,GOOG");
+    }
+
+    #[test]
+    fn test_symbols_empty_display() {
+        let syms = Symbols::default();
+        assert_eq!(syms.to_string(), "");
+        assert!(syms.is_empty());
+    }
+
+    #[test]
+    fn test_history_interval_display_values() {
+        assert_eq!(HistoryInterval::Daily.to_string(), "daily");
+        assert_eq!(HistoryInterval::Weekly.to_string(), "weekly");
+        assert_eq!(HistoryInterval::Monthly.to_string(), "monthly");
+    }
+
+    #[test]
+    fn test_timesales_interval_display_values() {
+        assert_eq!(TimeSalesInterval::Tick.to_string(), "tick");
+        assert_eq!(TimeSalesInterval::OneMinute.to_string(), "1min");
+        assert_eq!(TimeSalesInterval::FiveMinutes.to_string(), "5min");
+        assert_eq!(TimeSalesInterval::FifteenMinutes.to_string(), "15min");
+    }
+
+    #[test]
+    fn test_session_filter_display() {
+        assert_eq!(SessionFilter::All.to_string(), "all");
+        assert_eq!(SessionFilter::Open.to_string(), "open");
+    }
+
+    #[test]
+    fn test_calendar_month_valid() {
+        assert!(CalendarMonth::new(1).is_ok());
+        assert!(CalendarMonth::new(12).is_ok());
+        assert_eq!(CalendarMonth::new(6).unwrap().to_string(), "6");
+    }
+
+    #[test]
+    fn test_calendar_month_invalid() {
+        assert!(CalendarMonth::new(0).is_err());
+        assert!(CalendarMonth::new(13).is_err());
+        assert!(CalendarMonth::new(100).is_err());
+    }
+
+    #[test]
+    fn test_calendar_year_display() {
+        assert_eq!(CalendarYear::new(2024).to_string(), "2024");
+    }
+
+    #[test]
+    fn test_greeks_display() {
+        assert_eq!(Greeks::new(true).to_string(), "true");
+        assert_eq!(Greeks::new(false).to_string(), "false");
+        assert_eq!(Greeks::from(true).to_string(), "true");
+    }
+
+    #[test]
+    fn test_delayed_flag_display() {
+        assert_eq!(DelayedFlag::new(true).to_string(), "true");
+        assert_eq!(DelayedFlag::new(false).to_string(), "false");
+        assert_eq!(DelayedFlag::from(true).to_string(), "true");
+    }
+
+    #[test]
+    fn test_include_all_roots_display() {
+        assert_eq!(IncludeAllRoots::new(true).to_string(), "true");
+        assert_eq!(IncludeAllRoots::from(false).to_string(), "false");
+    }
+
+    #[test]
+    fn test_include_strikes_display() {
+        assert_eq!(IncludeStrikes::new(true).to_string(), "true");
+        assert_eq!(IncludeStrikes::from(false).to_string(), "false");
+    }
+
+    #[test]
+    fn test_indexes_flag_display() {
+        assert_eq!(IndexesFlag::new(true).to_string(), "true");
+        assert_eq!(IndexesFlag::from(false).to_string(), "false");
+    }
+
+    #[test]
+    fn test_exchanges_display() {
+        let ex = Exchanges::new(vec!["N".to_string(), "Q".to_string(), "A".to_string()]);
+        assert_eq!(ex.to_string(), "N,Q,A");
+        assert!(!ex.is_empty());
+    }
+
+    #[test]
+    fn test_exchanges_empty_display() {
+        let ex = Exchanges::default();
+        assert_eq!(ex.to_string(), "");
+        assert!(ex.is_empty());
+    }
+
+    #[test]
+    fn test_security_types_display() {
+        let t = SecurityTypes::new(vec!["stock".to_string(), "etf".to_string()]);
+        assert_eq!(t.to_string(), "stock,etf");
+        assert!(!t.is_empty());
+    }
+
+    #[test]
+    fn test_security_types_empty_display() {
+        let t = SecurityTypes::default();
+        assert_eq!(t.to_string(), "");
+        assert!(t.is_empty());
+    }
+
+    #[test]
+    fn test_format_naive_date() {
+        let d = NaiveDate::from_ymd_opt(2024, 1, 15).expect("valid date");
+        assert_eq!(format_naive_date(&d), "2024-01-15");
+    }
+
+    #[test]
+    fn test_format_timesales_datetime() {
+        let dt = Utc.with_ymd_and_hms(2024, 1, 15, 9, 30, 0).unwrap();
+        assert_eq!(format_timesales_datetime(&dt), "2024-01-15 09:30");
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(32))]
+
+        #[test]
+        fn test_deserialize_quotes_response_from_json(response in any::<GetQuotesResponseWire>()) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetQuotesResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok(), "failed to deserialize: {:?}, json: {}", result, json);
+        }
+
+        #[test]
+        fn test_deserialize_option_chains_response_from_json(
+            response in any::<GetOptionChainsResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetOptionChainsResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok(), "failed: {:?}", result);
+        }
+
+        #[test]
+        fn test_deserialize_option_strikes_response_from_json(
+            response in any::<GetOptionStrikesResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetOptionStrikesResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_option_expirations_response_from_json(
+            response in any::<GetOptionExpirationsResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetOptionExpirationsResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_lookup_option_symbols_response_from_json(
+            response in any::<LookupOptionSymbolsResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<LookupOptionSymbolsResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_historical_quotes_response_from_json(
+            response in any::<GetHistoricalQuotesResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetHistoricalQuotesResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_timesales_response_from_json(
+            response in any::<GetTimeAndSalesResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetTimeAndSalesResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_etb_securities_response_from_json(
+            response in any::<GetEtbSecuritiesResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetEtbSecuritiesResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_clock_response_from_json(response in any::<GetClockResponseWire>()) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetClockResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_calendar_response_from_json(
+            response in any::<GetCalendarResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<GetCalendarResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_search_response_from_json(
+            response in any::<SearchCompaniesResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<SearchCompaniesResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+
+        #[test]
+        fn test_deserialize_lookup_symbol_response_from_json(
+            response in any::<LookupSymbolResponseWire>()
+        ) {
+            let json = serde_json::to_string_pretty(&response).expect("serialize");
+            let result: std::result::Result<LookupSymbolResponse, serde_json::Error> =
+                serde_json::from_str(&json);
+            assert!(result.is_ok());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the full Tradier Market Data REST surface under `src/market_data/`, exposing
13 typed endpoints through both `non_blocking::operation::MarketData` and
`blocking::operation::MarketData` traits on the existing HTTP client.

Mirrors the established `src/accounts/` layout: `api.rs`, `types.rs`, `test_support.rs`,
and co-located `*_schema.json` JSON Schemas.

## Endpoints implemented

| # | Method | Path | Trait method |
|---|--------|------|---------------|
| 1 | GET  | `/v1/markets/quotes`                | `get_quotes` |
| 2 | POST | `/v1/markets/quotes`                | `post_quotes` (form body) |
| 3 | GET  | `/v1/markets/options/chains`        | `get_option_chains` |
| 4 | GET  | `/v1/markets/options/strikes`       | `get_option_strikes` |
| 5 | GET  | `/v1/markets/options/expirations`   | `get_option_expirations` |
| 6 | GET  | `/v1/markets/options/lookup`        | `lookup_option_symbols` |
| 7 | GET  | `/v1/markets/history`               | `get_historical_quotes` |
| 8 | GET  | `/v1/markets/timesales`             | `get_time_and_sales` |
| 9 | GET  | `/v1/markets/etb`                   | `get_etb_securities` |
| 10 | GET | `/v1/markets/clock`                 | `get_clock` |
| 11 | GET | `/v1/markets/calendar`              | `get_calendar` |
| 12 | GET | `/v1/markets/search`                | `search_companies` |
| 13 | GET | `/v1/markets/lookup`                | `lookup_symbol` |

## Types and conventions

- Newtypes for boundary values: `Symbol`, `Symbols`, `Greeks`, `HistoryInterval`,
  `TimeSalesInterval`, `SessionFilter`, `CalendarMonth`, `CalendarYear`, `DelayedFlag`,
  `IncludeAllRoots`, `IncludeStrikes`, `IndexesFlag`, `Exchanges`, `SecurityTypes`.
- `chrono::NaiveDate` / `DateTime<Utc>` at the boundary; formatted as the upstream
  expects (`YYYY-MM-DD` for dates, `YYYY-MM-DD HH:MM` for timesales datetimes).
- `OneOrMany<T>` on every Tradier field that may come back as a single object or
  an array (quote lists, option legs, strikes, expirations, day bars, securities, etc.).
- New `Error::MarketDataParseError(String)` variant for domain value validation.
- Symmetric blocking / non_blocking traits, sealed via `utils::Sealed`.
- `bon`-free on this pass: all requests are simple arg lists; no builders needed yet.
- Zero new runtime dependencies.

## Test matrix

All tests are hermetic (`httpmock` + captured JSON wire fixtures + JSON Schema
validators). They never call the real Tradier API.

Per endpoint, the blocking client tests verify:
- Happy path with query-param / form-body assertions on the mock.
- Omission of optional query params when the caller passes `None`
  (verified with `httpmock::When::is_true` over `query_params()`).
- 4xx, 5xx, malformed-body, and refused-connection error paths for `get_quotes`
  and `get_etb_securities` as representative cases.

Per response type, proptest-driven tests verify:
- Wire fixtures round-trip back into the `Deserialize` types.
- Wire fixtures conform to the matching `*_schema.json` where one exists
  (quotes, chains, expirations, history, timesales, calendar, lookup).

Totals: `154 passed; 0 failed` lib + `6 passed; 0 failed` doc tests.

## Gates

- ``cargo build --release`` — zero warnings
- ``cargo clippy --all-targets --all-features -- -D warnings`` — zero warnings
- ``cargo fmt --all --check`` — clean
- ``cargo test --all-features`` — 154 lib + 6 doc tests, all green

## Notes

Based on the latest `origin/main` which includes PRs #26 (changelog automation)
and #27 (WS event types). Commits follow the Conventional Commits format consumed
by the newly introduced `cliff.toml`. Does not modify the wssession surface.

Closes #12