### PR TITLE
feat(streaming): finish WS streaming + add HTTP streaming (#11)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ async-trait = "0.1.89"
 bon = "3.0"
 chrono = { version = "0.4", features = ["serde"] }
 futures-util = "0.3"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"

--- a/README.md
+++ b/README.md
@@ -182,6 +182,51 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 ```
 
+### HTTP streaming
+
+When WebSockets are not reachable (strict corporate egress, aggressive
+NAT timeouts, …) the same event stream is available over HTTP
+chunked transfer. The helpers under `tradier::streaming::http_stream`
+reuse the pooled `reqwest::Client` on the existing REST client, so
+there is no extra connection pool to configure.
+
+```rust,no_run
+use futures_util::StreamExt;
+use tradier::non_blocking::Client;
+use tradier::streaming::http_stream;
+use tradier::wssession::MarketSession;
+use tradier::Config;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let config = Config::new();
+    let rest = Client::new(config.clone());
+
+    // Bootstrap a session id the usual way.
+    let session = MarketSession::new(&config).await?;
+    let symbols = ["AAPL".to_string(), "MSFT".to_string()];
+
+    let events =
+        http_stream::market_events(&rest, session.get_session_id(), &symbols, None, None, None, None)
+            .await?;
+    futures_util::pin_mut!(events);
+    while let Some(event) = events.next().await {
+        match event {
+            Ok(e) => println!("event: {:?}", e),
+            Err(e) => eprintln!("stream error: {e}"),
+        }
+    }
+    Ok(())
+}
+```
+
+A matching `http_stream::account_events` helper streams
+`AccountEvent` values. Both helpers surface non-2xx responses as
+`Error::NetworkError` and per-line decode failures as
+`Error::StreamDecodeError` without aborting the stream.
+
+See `examples/http_stream_market/main.rs` for a runnable demo.
+
 ## Development
 
 This project includes a Makefile for common development tasks:

--- a/examples/http_stream_market/main.rs
+++ b/examples/http_stream_market/main.rs
@@ -1,0 +1,71 @@
+//! # HTTP streaming example
+//!
+//! Demonstrates how to consume Tradier market events over the HTTP
+//! chunked-transfer fallback under
+//! [`tradier::streaming::http_stream`]. The helpers reuse the pooled
+//! `reqwest::Client` on the existing REST client.
+//!
+//! Reconnection is the caller's responsibility — the library surfaces
+//! typed errors and callers drive the retry loop. This example logs
+//! the first couple of events and exits.
+//!
+//! This example will only run end-to-end against a real Tradier
+//! account; `cargo run --example http_stream_market` needs a valid
+//! `TRADIER_ACCESS_TOKEN`. `cargo build --examples` compiles it
+//! without credentials.
+
+use futures_util::StreamExt;
+use tracing::{error, info};
+use tradier::non_blocking::Client;
+use tradier::streaming::http_stream;
+use tradier::utils::logger::setup_logger;
+use tradier::wssession::{MarketSession, MarketSessionFilter};
+use tradier::Config;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn core::error::Error>> {
+    setup_logger();
+
+    let config = Config::new();
+    let rest = Client::new(config.clone());
+
+    // Bootstrap a streaming session id (this is the same REST call the
+    // WebSocket flavor uses — HTTP streaming and WS streaming share
+    // session ids).
+    let session = MarketSession::new(&config).await?;
+    info!("HTTP streaming session bootstrapped");
+
+    let symbols = ["AAPL".to_string(), "MSFT".to_string()];
+    let filters = [MarketSessionFilter::QUOTE, MarketSessionFilter::TRADE];
+
+    let events = http_stream::market_events(
+        &rest,
+        session.get_session_id(),
+        &symbols,
+        Some(&filters),
+        Some(true),
+        Some(true),
+        None,
+    )
+    .await?;
+    futures_util::pin_mut!(events);
+
+    let mut printed = 0usize;
+    while let Some(event) = events.next().await {
+        match event {
+            Ok(ev) => {
+                info!(symbol = ev.symbol(), "market event");
+                printed += 1;
+                if printed >= 2 {
+                    break;
+                }
+            }
+            Err(e) => {
+                error!(error = %e, "stream error");
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/client/non_blocking.rs
+++ b/src/client/non_blocking.rs
@@ -44,6 +44,21 @@ impl TradierRestClient {
             .ok_or(Error::MissingAccessToken)
     }
 
+    /// Returns a reference to the pooled `reqwest::Client` so that
+    /// sibling crates (notably `streaming::http_stream`) can reuse the
+    /// same HTTP/TLS pool instead of constructing a new client per
+    /// stream.
+    #[inline]
+    pub(crate) fn http_client(&self) -> &reqwest::Client {
+        &self.http_client
+    }
+
+    /// Returns a reference to the [`Config`] this client was built with.
+    #[inline]
+    pub(crate) fn http_client_config(&self) -> &Config {
+        &self.http_client_config
+    }
+
     pub async fn make_service_call(
         &self,
         url: Url,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod accounts;
 mod client;
 pub mod common;
 mod market_data;
-mod streaming;
+pub mod streaming;
 mod trading;
 mod user;
 mod watchlists;

--- a/src/streaming/http_stream.rs
+++ b/src/streaming/http_stream.rs
@@ -1,15 +1,16 @@
 //! HTTP chunked-transfer streaming of Tradier events.
 //!
 //! Tradier exposes HTTP-streaming endpoints at
-//! `https://stream.tradier.com/v1/markets/events`. The body is a
-//! chunked stream of newline-delimited JSON events. Each line is one
-//! event.
+//! `https://stream.tradier.com/v1/markets/events` (market events) and
+//! `https://stream.tradier.com/v1/accounts/events` (account events).
+//! The body is a chunked stream of newline-delimited JSON events. Each
+//! line is one event.
 //!
-//! This module provides [`market_events`] — a `Stream`-returning
-//! helper that reuses the pooled `reqwest::Client` from
-//! [`crate::client::non_blocking::TradierRestClient`]. Callers that
-//! cannot use WebSockets (for instance, from behind strict corporate
-//! egress filters) can fall back to this.
+//! This module provides [`market_events`] and [`account_events`] —
+//! `Stream`-returning helpers that reuse the pooled `reqwest::Client`
+//! from [`crate::client::non_blocking::TradierRestClient`]. Callers
+//! that cannot use WebSockets (for instance, from behind strict
+//! corporate egress filters) can fall back to these.
 //!
 //! ## Error handling
 //!
@@ -30,6 +31,7 @@ use serde::Serialize;
 use tracing::{debug, info, warn};
 
 use crate::client::non_blocking::TradierRestClient;
+use crate::wssession::account_events::AccountEvent;
 use crate::wssession::events::MarketEvent;
 use crate::{Error, Result};
 
@@ -117,6 +119,69 @@ pub async fn market_events(
     Ok(ndjson_event_stream(
         response.bytes_stream(),
         MarketEvent::from_json,
+    ))
+}
+
+/// Streams account events over the Tradier HTTP chunked-transfer
+/// endpoint. Reuses the `reqwest::Client` on `client`.
+///
+/// # Parameters
+///
+/// - `client`: a [`TradierRestClient`] — the existing `reqwest::Client`
+///   on it is reused.
+/// - `session_id`: the session id minted by the REST session-bootstrap
+///   call. Passed as the `sessionid` query parameter.
+/// - `events`: optional list of event filters matching
+///   [`crate::wssession::AccountSessionEvent`] (`order`, `position`,
+///   `trade`, `fill`, `drop`). Passed as the `events` query
+///   parameter.
+/// - `exclude_accounts`: optional list of account numbers to mask from
+///   the stream. Passed as the `excludeAccounts` query parameter.
+///
+/// # Errors
+///
+/// Same shape as [`market_events`].
+pub async fn account_events(
+    client: &TradierRestClient,
+    session_id: &str,
+    events: Option<&[crate::wssession::AccountSessionEvent]>,
+    exclude_accounts: Option<&[String]>,
+) -> Result<impl Stream<Item = Result<AccountEvent>>> {
+    let config = client.http_client_config();
+    let base = &config.streaming.http_base_url;
+    let url = format!("{base}/v1/accounts/events");
+    let bearer = client.get_bearer_token()?;
+
+    let mut query: Vec<(&str, String)> = Vec::with_capacity(4);
+    query.push(("sessionid", session_id.to_owned()));
+    if let Some(events) = events {
+        for e in events {
+            query.push(("events", e.as_ref().to_owned()));
+        }
+    }
+    if let Some(excluded) = exclude_accounts {
+        for acct in excluded {
+            query.push(("excludeAccounts", acct.clone()));
+        }
+    }
+
+    info!(url = %url, "opening HTTP account event stream");
+    let response = client
+        .http_client()
+        .get(&url)
+        .bearer_auth(bearer)
+        .header("accept", "application/json")
+        .query(&query)
+        .send()
+        .await
+        .map_err(Error::NetworkError)?;
+
+    let response = error_for_non_success(response).await?;
+    debug!("HTTP account stream accepted, decoding body");
+
+    Ok(ndjson_event_stream(
+        response.bytes_stream(),
+        AccountEvent::from_json,
     ))
 }
 
@@ -371,6 +436,80 @@ mod tests {
         let client = TradierRestClient::new(config);
         let symbols = ["SPY".to_string()];
         let result = market_events(&client, "sid", &symbols, None, None, None, None).await;
+        assert!(matches!(result, Err(Error::NetworkError(_))));
+    }
+
+    #[tokio::test]
+    async fn test_http_account_stream_decodes_newline_delimited_events() {
+        let server = MockServer::start_async().await;
+        let body = format!(
+            "{order}\n{fill}\n",
+            order = r#"{"event":"order","id":1,"status":"open"}"#,
+            fill = r#"{"event":"fill","order_id":1,"quantity":50.0,"price":281.12}"#,
+        );
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/accounts/events");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .header("transfer-encoding", "chunked")
+                    .body(body);
+            })
+            .await;
+
+        let config = test_config(&server.base_url(), &server.base_url());
+        let client = TradierRestClient::new(config);
+        let stream = account_events(&client, "sid", None, None)
+            .await
+            .expect("account_events");
+        let collected: Vec<Result<AccountEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 2);
+        assert!(matches!(collected[0], Ok(AccountEvent::Order(_))));
+        assert!(matches!(collected[1], Ok(AccountEvent::Fill(_))));
+    }
+
+    #[tokio::test]
+    async fn test_http_account_stream_malformed_line_yields_decode_error_and_continues() {
+        let server = MockServer::start_async().await;
+        let body = format!(
+            "{order}\nnot-json\n{fill}\n",
+            order = r#"{"event":"order","id":1,"status":"open"}"#,
+            fill = r#"{"event":"fill","order_id":1,"quantity":50.0,"price":281.12}"#,
+        );
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/accounts/events");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(body);
+            })
+            .await;
+
+        let config = test_config(&server.base_url(), &server.base_url());
+        let client = TradierRestClient::new(config);
+        let stream = account_events(&client, "sid", None, None)
+            .await
+            .expect("account_events");
+        let collected: Vec<Result<AccountEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 3, "got {collected:?}");
+        assert!(matches!(collected[0], Ok(AccountEvent::Order(_))));
+        assert!(matches!(collected[1], Err(Error::StreamDecodeError(_, _))));
+        assert!(matches!(collected[2], Ok(AccountEvent::Fill(_))));
+    }
+
+    #[tokio::test]
+    async fn test_http_account_stream_non_success_surfaces_network_error() {
+        let server = MockServer::start_async().await;
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/accounts/events");
+                then.status(500).body("boom");
+            })
+            .await;
+
+        let config = test_config(&server.base_url(), &server.base_url());
+        let client = TradierRestClient::new(config);
+        let result = account_events(&client, "sid", None, None).await;
         assert!(matches!(result, Err(Error::NetworkError(_))));
     }
 }

--- a/src/streaming/http_stream.rs
+++ b/src/streaming/http_stream.rs
@@ -1,0 +1,376 @@
+//! HTTP chunked-transfer streaming of Tradier events.
+//!
+//! Tradier exposes HTTP-streaming endpoints at
+//! `https://stream.tradier.com/v1/markets/events`. The body is a
+//! chunked stream of newline-delimited JSON events. Each line is one
+//! event.
+//!
+//! This module provides [`market_events`] — a `Stream`-returning
+//! helper that reuses the pooled `reqwest::Client` from
+//! [`crate::client::non_blocking::TradierRestClient`]. Callers that
+//! cannot use WebSockets (for instance, from behind strict corporate
+//! egress filters) can fall back to this.
+//!
+//! ## Error handling
+//!
+//! - Non-2xx HTTP status is surfaced as
+//!   [`crate::Error::NetworkError`] before the stream is constructed,
+//!   so callers get the status synchronously from the returned
+//!   `Result`.
+//! - Per-chunk transport errors surface as `Err(Error::NetworkError)`
+//!   items of the stream.
+//! - Per-line decode failures surface as
+//!   `Err(Error::StreamDecodeError(_, _))` items — consistent with the
+//!   WebSocket decoder. Decode failures do NOT abort the stream.
+
+use std::collections::VecDeque;
+
+use futures_util::stream::{Stream, StreamExt};
+use serde::Serialize;
+use tracing::{debug, info, warn};
+
+use crate::client::non_blocking::TradierRestClient;
+use crate::wssession::events::MarketEvent;
+use crate::{Error, Result};
+
+/// Streams market events over the Tradier HTTP chunked-transfer
+/// endpoint. The endpoint path is resolved against
+/// [`crate::config::StreamingConfig::http_base_url`] with
+/// `/v1/markets/events`.
+///
+/// # Parameters
+///
+/// - `client`: a [`TradierRestClient`] — the existing `reqwest::Client`
+///   on it is reused.
+/// - `session_id`: the session id minted by the REST session-bootstrap
+///   call. Passed as the `sessionid` query parameter per the upstream
+///   contract.
+/// - `symbols`: symbols to subscribe to. Tradier accepts a
+///   comma-separated list in the `symbols` query parameter.
+/// - `filters`: optional list of event-type filters, matching
+///   [`crate::wssession::MarketSessionFilter`] values (`quote`,
+///   `trade`, `summary`, `timesale`, `tradex`). Passed as `filter`.
+/// - `linebreak`: optional `linebreak=true|false`.
+/// - `valid_only`: optional `validOnly=true|false`.
+/// - `advanced_details`: optional `advancedDetails=true|false`.
+///
+/// # Errors
+///
+/// - [`Error::UrlParsingError`] if the HTTP streaming base URL is
+///   malformed.
+/// - [`Error::NetworkError`] if the initial request fails (connect /
+///   handshake) OR the server responds with a non-2xx status.
+/// - [`Error::MissingAccessToken`] if the client config has no access
+///   token.
+///
+/// Once the stream is established, per-chunk and per-line errors
+/// surface as `Err(_)` items of the stream.
+pub async fn market_events(
+    client: &TradierRestClient,
+    session_id: &str,
+    symbols: &[String],
+    filters: Option<&[crate::wssession::MarketSessionFilter]>,
+    linebreak: Option<bool>,
+    valid_only: Option<bool>,
+    advanced_details: Option<bool>,
+) -> Result<impl Stream<Item = Result<MarketEvent>>> {
+    let config = client.http_client_config();
+    let base = &config.streaming.http_base_url;
+    let url = format!("{base}/v1/markets/events");
+    let bearer = client.get_bearer_token()?;
+
+    // Tradier's HTTP streaming accepts the same filters as the WS
+    // subscription payload. We serialize them to their `as_ref()`
+    // string representations.
+    let mut query: Vec<(&str, String)> = Vec::with_capacity(7);
+    query.push(("sessionid", session_id.to_owned()));
+    query.push(("symbols", symbols.join(",")));
+    if let Some(filters) = filters {
+        for f in filters {
+            query.push(("filter", f.as_ref().to_owned()));
+        }
+    }
+    if let Some(lb) = linebreak {
+        query.push(("linebreak", lb.to_string()));
+    }
+    if let Some(v) = valid_only {
+        query.push(("validOnly", v.to_string()));
+    }
+    if let Some(a) = advanced_details {
+        query.push(("advancedDetails", a.to_string()));
+    }
+
+    info!(url = %url, "opening HTTP market event stream");
+    let response = client
+        .http_client()
+        .get(&url)
+        .bearer_auth(bearer)
+        .header("accept", "application/json")
+        .query(&query)
+        .send()
+        .await
+        .map_err(Error::NetworkError)?;
+
+    let response = error_for_non_success(response).await?;
+    debug!("HTTP market stream accepted, decoding body");
+
+    Ok(ndjson_event_stream(
+        response.bytes_stream(),
+        MarketEvent::from_json,
+    ))
+}
+
+/// Opaque subscription query — currently unused but reserved for
+/// callers that want to supply a typed struct rather than bare
+/// parameters. Kept here so that future work can wire a builder
+/// without reshaping the module surface.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize)]
+pub(crate) struct HttpStreamQuery<'a> {
+    pub sessionid: &'a str,
+}
+
+/// Rejects non-2xx responses up front so that callers can decide
+/// whether to reconnect without having to drain a body first.
+async fn error_for_non_success(response: reqwest::Response) -> Result<reqwest::Response> {
+    let status = response.status();
+    if status.is_success() {
+        return Ok(response);
+    }
+    warn!(status = %status, "HTTP stream rejected");
+    // Convert the status into a `reqwest::Error` via `error_for_status`
+    // so the caller gets the HTTP status code preserved.
+    match response.error_for_status() {
+        Ok(r) => Ok(r), // unreachable in practice; keeps the type right
+        Err(e) => Err(Error::NetworkError(e)),
+    }
+}
+
+/// Internal decoder state shared across [`futures_util::stream::unfold`]
+/// iterations: a chunked reqwest byte stream plus a rolling buffer of
+/// partially-received bytes and a queue of decoded events waiting to
+/// surface.
+struct NdjsonState<S, T, F> {
+    body: S,
+    buffer: Vec<u8>,
+    pending: VecDeque<Result<T>>,
+    decode: F,
+    finished: bool,
+}
+
+/// Wraps the body byte stream from a `reqwest::Response` in a
+/// newline-delimited JSON decoder that yields `Result<T>` items.
+///
+/// - Transport errors become `Err(Error::NetworkError)` and terminate
+///   the stream.
+/// - Decode errors become `Err(Error::StreamDecodeError)` and are
+///   yielded without terminating the stream.
+/// - End-of-body flushes any remaining non-empty line.
+#[inline]
+fn ndjson_event_stream<S, B, T, F>(body: S, decode: F) -> impl Stream<Item = Result<T>>
+where
+    S: Stream<Item = reqwest::Result<B>> + Unpin,
+    B: AsRef<[u8]>,
+    F: Fn(&str) -> Result<T>,
+{
+    let state = NdjsonState {
+        body,
+        buffer: Vec::with_capacity(4096),
+        pending: VecDeque::new(),
+        decode,
+        finished: false,
+    };
+
+    futures_util::stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(item) = state.pending.pop_front() {
+                return Some((item, state));
+            }
+            if state.finished {
+                return None;
+            }
+            match state.body.next().await {
+                Some(Ok(chunk)) => {
+                    state.buffer.extend_from_slice(chunk.as_ref());
+                    drain_complete_lines(&mut state.buffer, &mut state.pending, &state.decode);
+                }
+                Some(Err(e)) => {
+                    warn!(error = %e, "HTTP stream transport error");
+                    state.finished = true;
+                    state.pending.push_back(Err(Error::NetworkError(e)));
+                }
+                None => {
+                    // Flush the final line, if any.
+                    if !state.buffer.is_empty() {
+                        let tail = std::mem::take(&mut state.buffer);
+                        match std::str::from_utf8(&tail) {
+                            Ok(s) => {
+                                let trimmed = s.trim();
+                                if !trimmed.is_empty() {
+                                    state.pending.push_back((state.decode)(trimmed));
+                                }
+                            }
+                            Err(e) => {
+                                state.pending.push_back(Err(Error::StreamDecodeError(
+                                    String::from_utf8_lossy(&tail).into_owned(),
+                                    e.to_string(),
+                                )));
+                            }
+                        }
+                    }
+                    state.finished = true;
+                }
+            }
+        }
+    })
+}
+
+/// Pulls every complete `\n`-terminated line out of `buffer` and pushes
+/// the decoded result onto `pending`. Any partial trailing line stays
+/// in `buffer` for the next chunk.
+fn drain_complete_lines<T, F>(buffer: &mut Vec<u8>, pending: &mut VecDeque<Result<T>>, decode: &F)
+where
+    F: Fn(&str) -> Result<T>,
+{
+    while let Some(pos) = memchr_newline(buffer) {
+        // Split off the first line including the newline.
+        let rest = buffer.split_off(pos + 1);
+        let line_bytes = std::mem::replace(buffer, rest);
+        // Drop the trailing \n (and a preceding \r if present).
+        let line_len = line_bytes.len().saturating_sub(1);
+        let mut line = &line_bytes[..line_len];
+        if line.last() == Some(&b'\r') {
+            line = &line[..line.len() - 1];
+        }
+        if line.is_empty() {
+            continue;
+        }
+        match std::str::from_utf8(line) {
+            Ok(s) => {
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                pending.push_back(decode(trimmed));
+            }
+            Err(e) => {
+                pending.push_back(Err(Error::StreamDecodeError(
+                    String::from_utf8_lossy(line).into_owned(),
+                    e.to_string(),
+                )));
+            }
+        }
+    }
+}
+
+#[inline]
+fn memchr_newline(haystack: &[u8]) -> Option<usize> {
+    haystack.iter().position(|b| *b == b'\n')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, Credentials, RestApiConfig, StreamingConfig};
+    use httpmock::prelude::*;
+
+    fn test_config(server_url: &str, stream_url: &str) -> Config {
+        Config {
+            credentials: Credentials {
+                client_id: "test".into(),
+                client_secret: "test".into(),
+                access_token: Some("token".into()),
+                refresh_token: None,
+            },
+            rest_api: RestApiConfig {
+                base_url: server_url.to_string(),
+                timeout: 30,
+            },
+            streaming: StreamingConfig {
+                http_base_url: stream_url.to_string(),
+                ws_base_url: String::new(),
+                events_path: String::new(),
+                reconnect_interval: 5,
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn test_http_market_stream_decodes_newline_delimited_events() {
+        let server = MockServer::start_async().await;
+        let body = format!(
+            "{quote}\n{trade}\n",
+            quote = r#"{"type":"quote","symbol":"C","bid":281.84,"bidsz":60,"bidexch":"M","biddate":"1","ask":281.85,"asksz":6,"askexch":"Z","askdate":"2"}"#,
+            trade = r#"{"type":"trade","symbol":"SPY","exch":"Q","price":"281.12","size":"100","cvol":"1","date":"3","last":"281.12"}"#,
+        );
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/markets/events");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .header("transfer-encoding", "chunked")
+                    .body(body);
+            })
+            .await;
+
+        let config = test_config(&server.base_url(), &server.base_url());
+        let client = TradierRestClient::new(config);
+        let symbols = ["SPY".to_string()];
+        let stream = market_events(&client, "sid", &symbols, None, None, None, None)
+            .await
+            .expect("market_events");
+        let collected: Vec<Result<MarketEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 2);
+        assert!(matches!(collected[0], Ok(MarketEvent::Quote(_))));
+        assert!(matches!(collected[1], Ok(MarketEvent::Trade(_))));
+    }
+
+    #[tokio::test]
+    async fn test_http_market_stream_malformed_line_yields_decode_error_and_continues() {
+        let server = MockServer::start_async().await;
+        let body = format!(
+            "{quote}\nnot-json\n{trade}\n",
+            quote = r#"{"type":"quote","symbol":"C","bid":281.84,"bidsz":60,"bidexch":"M","biddate":"1","ask":281.85,"asksz":6,"askexch":"Z","askdate":"2"}"#,
+            trade = r#"{"type":"trade","symbol":"SPY","exch":"Q","price":"281.12","size":"100","cvol":"1","date":"3","last":"281.12"}"#,
+        );
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/markets/events");
+                then.status(200)
+                    .header("content-type", "application/json")
+                    .body(body);
+            })
+            .await;
+
+        let config = test_config(&server.base_url(), &server.base_url());
+        let client = TradierRestClient::new(config);
+        let symbols = ["SPY".to_string()];
+        let stream = market_events(&client, "sid", &symbols, None, None, None, None)
+            .await
+            .expect("market_events");
+        let collected: Vec<Result<MarketEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 3, "got {collected:?}");
+        assert!(matches!(collected[0], Ok(MarketEvent::Quote(_))));
+        assert!(matches!(collected[1], Err(Error::StreamDecodeError(_, _))));
+        assert!(matches!(collected[2], Ok(MarketEvent::Trade(_))));
+    }
+
+    #[tokio::test]
+    async fn test_http_market_stream_non_success_surfaces_network_error() {
+        let server = MockServer::start_async().await;
+        let _mock = server
+            .mock_async(|when, then| {
+                when.method(GET).path("/v1/markets/events");
+                then.status(401)
+                    .header("content-type", "application/json")
+                    .body("unauthorized");
+            })
+            .await;
+
+        let config = test_config(&server.base_url(), &server.base_url());
+        let client = TradierRestClient::new(config);
+        let symbols = ["SPY".to_string()];
+        let result = market_events(&client, "sid", &symbols, None, None, None, None).await;
+        assert!(matches!(result, Err(Error::NetworkError(_))));
+    }
+}

--- a/src/streaming/mod.rs
+++ b/src/streaming/mod.rs
@@ -1,1 +1,16 @@
+//! # Tradier streaming
+//!
+//! Building blocks for the REST session bootstrap and the HTTP
+//! chunked-transfer event streams.
+//!
+//! - [`http_stream`] exposes the HTTP-stream helpers —
+//!   `Stream`-returning functions that reuse the pooled
+//!   `reqwest::Client` on a
+//!   [`crate::client::non_blocking::TradierRestClient`]. These are the
+//!   HTTP fallback when WebSockets are not reachable.
+//!
+//! The REST endpoint that mints the session id itself lives under
+//! [`crate::wssession::session`] (it is shared between the WebSocket
+//! and HTTP streaming flavors).
 
+pub mod http_stream;

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -139,6 +139,98 @@ pub(crate) async fn mock_websocket_server(
     });
 }
 
+/// Scripted actions a mock WebSocket server can play against a client,
+/// in order. Designed for tests of the event-stream decoders under
+/// `wssession::market` and `wssession::account`.
+#[cfg(test)]
+#[derive(Clone, Debug)]
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum ScriptedWsAction {
+    /// Send a single `Message::Text` frame with this payload.
+    SendText(&'static str),
+    /// Send a `Message::Ping` frame (server-initiated).
+    SendPing(&'static [u8]),
+    /// Send a `Message::Close` frame with `CloseCode::Normal`.
+    SendClose,
+}
+
+/// Minimal scripted WebSocket server for event-stream tests.
+///
+/// The server:
+/// - Accepts one client connection on `address`.
+/// - Reads the client's subscription frame and hands it to
+///   `on_subscription` (which may assert on the payload).
+/// - Replays `script` in order and then ends the task.
+///
+/// Tests pick a port with [`free_tcp_port`] so they can run in parallel.
+#[cfg(test)]
+pub(crate) async fn scripted_websocket_server<F>(
+    address: (&'static str, u16),
+    script: Vec<ScriptedWsAction>,
+    on_subscription: F,
+) where
+    F: FnOnce(&str) + Send + 'static,
+{
+    let listener = TcpListener::bind(address).await.expect("bind mock ws");
+    tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept mock ws");
+        let mut websocket = accept_async(stream).await.expect("ws handshake");
+
+        // Drain the subscription frame.
+        match websocket.next().await {
+            Some(Ok(Message::Text(msg))) => on_subscription(msg.as_ref()),
+            other => panic!("expected subscription text frame, got {other:?}"),
+        }
+
+        for action in script {
+            match action {
+                ScriptedWsAction::SendText(payload) => {
+                    websocket
+                        .send(Message::Text(payload.into()))
+                        .await
+                        .expect("send text");
+                }
+                ScriptedWsAction::SendPing(payload) => {
+                    websocket
+                        .send(Message::Ping(payload.to_vec().into()))
+                        .await
+                        .expect("send ping");
+                    // Let tokio-tungstenite push the pong back. We
+                    // consume one frame so the peer's pong does not
+                    // show up as a surprise when we next read.
+                    match websocket.next().await {
+                        Some(Ok(Message::Pong(_))) => {}
+                        Some(Ok(other)) => panic!("expected pong, got {other:?}"),
+                        Some(Err(e)) => panic!("ws error waiting for pong: {e}"),
+                        None => panic!("connection closed waiting for pong"),
+                    }
+                }
+                ScriptedWsAction::SendClose => {
+                    websocket
+                        .close(Some(CloseFrame {
+                            code: CloseCode::Normal,
+                            reason: "done".into(),
+                        }))
+                        .await
+                        .expect("send close");
+                }
+            }
+        }
+    });
+}
+
+/// Reserves an unused local TCP port by binding to `127.0.0.1:0` and
+/// dropping the listener. Good enough for hermetic tests — the window
+/// where the port could be reclaimed is tiny and the test owns the
+/// process.
+#[cfg(test)]
+pub(crate) fn free_tcp_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind to ephemeral port");
+    let port = listener.local_addr().expect("local addr").port();
+    drop(listener);
+    port
+}
+
 #[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
 pub struct DateTimeUtcWire(#[proptest(strategy = "arb_date_time_strategy()")] DateTime<Utc>);
 

--- a/src/wssession/account.rs
+++ b/src/wssession/account.rs
@@ -61,13 +61,15 @@
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 
+use futures_util::stream::Stream;
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use tokio_tungstenite::connect_async;
-use tracing::{error, info};
+use tracing::{debug, info, trace, warn};
 use tungstenite::Message;
 use url::Url;
 
+use crate::wssession::account_events::AccountEvent;
 use crate::wssession::session::{Session, SessionType};
 use crate::Config;
 use crate::{Error, Result};
@@ -292,47 +294,81 @@ impl<'a> AccountSession<'a> {
         self.0.get_websocket_url()
     }
 
-    /// Opens the account WebSocket, sends the payload, and streams events
-    /// until the peer closes the connection or an error occurs.
+    /// Opens the account WebSocket and returns an async [`Stream`] of
+    /// typed [`AccountEvent`] values.
+    ///
+    /// Each upstream text frame is split on `\n` so a single frame that
+    /// bundles multiple newline-delimited JSON events still decodes as
+    /// separate items.
+    ///
+    /// Decode failures surface as `Err(Error::StreamDecodeError(...))`
+    /// items and do NOT abort the stream. Peer-initiated `Close` ends
+    /// the stream without yielding an error. `Ping` frames are answered
+    /// automatically by `tokio_tungstenite`.
+    ///
+    /// Reconnect policy is the caller's responsibility.
     ///
     /// # Errors
     /// - [`Error::UrlParsingError`] if the session URL is invalid.
-    /// - [`Error::WebSocketError`] if the handshake, send, or receive fails.
-    /// - [`Error::JsonParsingError`] if the payload cannot be serialized.
+    /// - [`Error::WebSocketError`] if the handshake or initial payload
+    ///   send fails.
+    /// - [`Error::JsonParsingError`] if the subscription payload cannot
+    ///   be serialized.
     ///
-    /// Reconnect policy is the caller's responsibility.
-    pub async fn ws_stream(&self, payload: AccountSessionPayload<'a>) -> Result<()> {
+    /// After the stream is established, per-frame errors are yielded as
+    /// `Err(_)` items of the stream rather than aborting early.
+    pub async fn event_stream(
+        &self,
+        payload: AccountSessionPayload<'a>,
+    ) -> Result<impl Stream<Item = Result<AccountEvent>>> {
         let uri = self.0.get_websocket_url();
         let url = Url::parse(uri)?;
 
-        info!(url = %uri, "Connecting to account stream");
+        info!(url = %uri, "connecting to account stream");
         let (ws_stream, _) = connect_async(url.as_str()).await.map_err(Box::new)?;
-        let (mut write, mut read) = ws_stream.split();
+        let (mut write, read) = ws_stream.split();
 
         let message = payload.get_message()?;
         write.send(message).await.map_err(Box::new)?;
-        info!("Sent account session payload");
+        debug!("sent account subscription payload");
 
-        while let Some(message) = read.next().await {
-            match message {
-                Ok(Message::Text(text)) => {
-                    info!(bytes = text.len(), "account event text");
+        Ok(super::ws_decode::ws_event_stream(
+            read,
+            AccountEvent::from_json,
+        ))
+    }
+
+    /// Opens the account WebSocket, sends the payload, and streams events
+    /// until the peer closes the connection or an error occurs.
+    ///
+    /// Kept for back-compat — internally drives [`Self::event_stream`]
+    /// and logs each parsed event at `TRACE`, each decode error at
+    /// `WARN`. Prefer [`Self::event_stream`] for new code.
+    ///
+    /// # Errors
+    /// Same as [`Self::event_stream`].
+    pub async fn ws_stream(&self, payload: AccountSessionPayload<'a>) -> Result<()> {
+        let stream = self.event_stream(payload).await?;
+        futures_util::pin_mut!(stream);
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(event) => {
+                    // Do not log the account number in clear — record only
+                    // whether it was present on the event.
+                    trace!(
+                        has_account = event.account_number().is_some(),
+                        "account event"
+                    );
                 }
-                Ok(Message::Binary(data)) => {
-                    info!(bytes = data.len(), "account event binary");
-                }
-                Ok(Message::Close(frame)) => {
-                    info!(?frame, "account stream closed");
-                    break;
+                Err(Error::StreamDecodeError(_, err)) => {
+                    warn!(error = %err, "decode failure on account frame, continuing");
                 }
                 Err(e) => {
-                    error!(error = %e, "account stream read error");
-                    return Err(Error::WebSocketError(Box::new(e)));
+                    warn!(error = %e, "account stream error, terminating");
+                    return Err(e);
                 }
-                _ => {}
             }
         }
-
         Ok(())
     }
 }
@@ -342,7 +378,12 @@ mod tests {
     use mockito::Server;
 
     use super::*;
-    use crate::{utils::tests::create_test_config, wssession::session_manager::SessionManager};
+    use crate::{
+        utils::tests::{
+            create_test_config, free_tcp_port, scripted_websocket_server, ScriptedWsAction,
+        },
+        wssession::session_manager::SessionManager,
+    };
 
     #[test]
     fn test_account_session_event_as_ref() {
@@ -441,5 +482,141 @@ mod tests {
             );
         }
         mock.assert_async().await;
+    }
+
+    // ===== event_stream tests =====
+
+    const ORDER_FRAME: &str = r#"{"event":"order","id":123,"status":"filled","account_number":"VA1234","symbol":"SPY","quantity":100.0,"executed_quantity":100.0}"#;
+    const FILL_FRAME: &str = r#"{"event":"fill","order_id":123,"account_number":"VA1234","symbol":"SPY","side":"buy","quantity":100.0,"price":281.12}"#;
+    const POSITION_FRAME: &str = r#"{"event":"position","account_number":"VA1234","symbol":"SPY","quantity":100.0,"cost_basis":28112.0}"#;
+    const BALANCE_FRAME: &str = r#"{"event":"balance","account_number":"VA1234","total_equity":100000.0,"total_cash":50000.0}"#;
+    const TRADE_FRAME: &str = r#"{"event":"trade","account_number":"VA1234","symbol":"SPY","side":"buy","quantity":100.0,"price":281.12}"#;
+    const DROP_FRAME: &str =
+        r#"{"event":"drop","account_number":"VA1234","reason":"session expired"}"#;
+    const MALFORMED_FRAME: &str = r#"{"event":"order","id":123,"status":"#;
+
+    /// Boots an account session wired to a leaked `SessionManager` and
+    /// `Config` so the returned session satisfies `'static`.
+    async fn build_account_session_against_port(port: u16) -> AccountSession<'static> {
+        let server = Box::leak(Box::new(Server::new_async().await));
+        let json_data = format!(
+            r#"
+        {{
+            "stream": {{
+                "url": "ws://127.0.0.1:{port}/v1/accounts/events",
+                "sessionid": "c8638963-a6d4-4fb9-9bc6-e25fbd8c60c3"
+            }}
+        }}
+        "#
+        );
+        server
+            .mock("POST", "/v1/accounts/events/session")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json_data)
+            .create_async()
+            .await;
+
+        let config = Box::leak(Box::new(
+            create_test_config().server_url(&server.url()).finish(),
+        ));
+        let session_manager: &'static SessionManager =
+            Box::leak(Box::new(SessionManager::default()));
+        AccountSession::new_with_session_manager(config, session_manager)
+            .await
+            .expect("account session")
+    }
+
+    #[tokio::test]
+    async fn test_account_event_stream_yields_typed_events_in_order() {
+        let port = free_tcp_port();
+        let session = build_account_session_against_port(port).await;
+
+        scripted_websocket_server(
+            ("127.0.0.1", port),
+            vec![
+                ScriptedWsAction::SendText(ORDER_FRAME),
+                ScriptedWsAction::SendText(FILL_FRAME),
+                ScriptedWsAction::SendText(POSITION_FRAME),
+                ScriptedWsAction::SendText(BALANCE_FRAME),
+                ScriptedWsAction::SendText(TRADE_FRAME),
+                ScriptedWsAction::SendText(DROP_FRAME),
+                ScriptedWsAction::SendClose,
+            ],
+            |_sub| {},
+        )
+        .await;
+
+        let events = [AccountSessionEvent::Order];
+        let payload = AccountSessionPayload::builder()
+            .events(&events)
+            .session_id(session.get_session_id())
+            .build();
+
+        let stream = session.event_stream(payload).await.expect("event_stream");
+        let collected: Vec<Result<AccountEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 6, "expected 6 events, got {collected:?}");
+        assert!(matches!(collected[0], Ok(AccountEvent::Order(_))));
+        assert!(matches!(collected[1], Ok(AccountEvent::Fill(_))));
+        assert!(matches!(collected[2], Ok(AccountEvent::Position(_))));
+        assert!(matches!(collected[3], Ok(AccountEvent::Balance(_))));
+        assert!(matches!(collected[4], Ok(AccountEvent::Trade(_))));
+        assert!(matches!(collected[5], Ok(AccountEvent::Drop(_))));
+    }
+
+    #[tokio::test]
+    async fn test_account_event_stream_malformed_frame_yields_decode_error_and_continues() {
+        let port = free_tcp_port();
+        let session = build_account_session_against_port(port).await;
+
+        scripted_websocket_server(
+            ("127.0.0.1", port),
+            vec![
+                ScriptedWsAction::SendText(ORDER_FRAME),
+                ScriptedWsAction::SendText(MALFORMED_FRAME),
+                ScriptedWsAction::SendText(FILL_FRAME),
+                ScriptedWsAction::SendClose,
+            ],
+            |_sub| {},
+        )
+        .await;
+
+        let events = [AccountSessionEvent::Order];
+        let payload = AccountSessionPayload::builder()
+            .events(&events)
+            .session_id(session.get_session_id())
+            .build();
+        let stream = session.event_stream(payload).await.expect("event_stream");
+        let collected: Vec<Result<AccountEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 3, "expected 3 items, got {collected:?}");
+        assert!(matches!(collected[0], Ok(AccountEvent::Order(_))));
+        assert!(matches!(collected[1], Err(Error::StreamDecodeError(_, _))));
+        assert!(matches!(collected[2], Ok(AccountEvent::Fill(_))));
+    }
+
+    #[tokio::test]
+    async fn test_account_event_stream_peer_close_terminates_without_error() {
+        let port = free_tcp_port();
+        let session = build_account_session_against_port(port).await;
+
+        scripted_websocket_server(
+            ("127.0.0.1", port),
+            vec![
+                ScriptedWsAction::SendText(ORDER_FRAME),
+                ScriptedWsAction::SendClose,
+            ],
+            |_sub| {},
+        )
+        .await;
+
+        let events = [AccountSessionEvent::Order];
+        let payload = AccountSessionPayload::builder()
+            .events(&events)
+            .session_id(session.get_session_id())
+            .build();
+        let stream = session.event_stream(payload).await.expect("event_stream");
+        let collected: Vec<Result<AccountEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 1);
+        assert!(collected[0].is_ok());
     }
 }

--- a/src/wssession/account_events.rs
+++ b/src/wssession/account_events.rs
@@ -1,0 +1,406 @@
+//! Tradier WebSocket account event response types.
+//!
+//! See <https://documentation.tradier.com/brokerage-api/streaming/wss-account-websocket>
+//! for the upstream contract.
+//!
+//! The account stream emits one JSON object per line. The top-level
+//! `event` field discriminates the variant: `order`, `fill`, `position`,
+//! `balance`, `trade`, `drop`.
+//!
+//! Numeric fields are taken at the upstream type — Tradier sends
+//! quantities as `f64` and timestamps as millisecond-epoch strings, so
+//! we mirror that shape exactly. Callers that need decimal precision
+//! convert at the boundary rather than have the library silently coerce.
+//!
+//! Variants are `#[non_exhaustive]` so new event kinds can be added in
+//! a minor release without a breaking change.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{Error, Result};
+
+/// An account event received from the Tradier WebSocket stream.
+///
+/// Tagged on the upstream `event` field. Unknown variants are rejected
+/// with a deserialization error — callers that want
+/// forward-compatibility should deserialize into [`serde_json::Value`]
+/// first and then into [`AccountEvent`].
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(tag = "event", rename_all = "lowercase")]
+#[non_exhaustive]
+pub enum AccountEvent {
+    /// Order lifecycle update (new, partially filled, filled,
+    /// cancelled, rejected, ...).
+    Order(AccountOrderEvent),
+    /// Individual fill (execution) event attached to an order.
+    Fill(AccountFillEvent),
+    /// Position update (quantity / cost basis changed).
+    Position(AccountPositionEvent),
+    /// Balance update (cash / buying power / equity).
+    Balance(AccountBalanceEvent),
+    /// Aggregated trade event.
+    Trade(AccountTradeEvent),
+    /// Session dropped / account unsubscribed.
+    Drop(AccountDropEvent),
+}
+
+/// Order lifecycle event.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct AccountOrderEvent {
+    /// Tradier order id.
+    pub id: u64,
+    /// Order status (`open`, `partially_filled`, `filled`, `canceled`,
+    /// `rejected`, ...). Left as `String` so new upstream values do
+    /// not break deserialization.
+    pub status: String,
+    /// Account number the order belongs to.
+    #[serde(
+        rename = "account_number",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub account_number: Option<String>,
+    /// Symbol the order is against.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// Side (`buy`, `sell`, `buy_to_cover`, `sell_short`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub side: Option<String>,
+    /// Requested quantity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quantity: Option<f64>,
+    /// Remaining quantity (unfilled).
+    #[serde(
+        rename = "remaining_quantity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub remaining_quantity: Option<f64>,
+    /// Executed / filled quantity.
+    #[serde(
+        rename = "executed_quantity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub executed_quantity: Option<f64>,
+    /// Average fill price across all fills.
+    #[serde(
+        rename = "avg_fill_price",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub avg_fill_price: Option<f64>,
+    /// Most recent fill price.
+    #[serde(
+        rename = "last_fill_price",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub last_fill_price: Option<f64>,
+    /// Most recent fill quantity.
+    #[serde(
+        rename = "last_fill_quantity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub last_fill_quantity: Option<f64>,
+    /// Event timestamp (millisecond-epoch string on the wire).
+    #[serde(
+        rename = "transaction_date",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub transaction_date: Option<String>,
+}
+
+/// Individual execution / fill attached to an order.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct AccountFillEvent {
+    /// Parent order id.
+    #[serde(rename = "order_id", default, skip_serializing_if = "Option::is_none")]
+    pub order_id: Option<u64>,
+    /// Account number.
+    #[serde(
+        rename = "account_number",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub account_number: Option<String>,
+    /// Symbol that filled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// Side of the fill.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub side: Option<String>,
+    /// Filled quantity on this print.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quantity: Option<f64>,
+    /// Fill price on this print.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub price: Option<f64>,
+    /// Execution timestamp.
+    #[serde(
+        rename = "transaction_date",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub transaction_date: Option<String>,
+}
+
+/// Position update.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct AccountPositionEvent {
+    /// Account number.
+    #[serde(
+        rename = "account_number",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub account_number: Option<String>,
+    /// Position symbol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// New signed quantity (positive = long, negative = short).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quantity: Option<f64>,
+    /// Total cost basis of the position.
+    #[serde(
+        rename = "cost_basis",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub cost_basis: Option<f64>,
+    /// Update timestamp.
+    #[serde(
+        rename = "date_acquired",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub date_acquired: Option<String>,
+}
+
+/// Balance update.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct AccountBalanceEvent {
+    /// Account number.
+    #[serde(
+        rename = "account_number",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub account_number: Option<String>,
+    /// Total account value (cash + long-market-value - short-market-value).
+    #[serde(
+        rename = "total_equity",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub total_equity: Option<f64>,
+    /// Available cash.
+    #[serde(
+        rename = "total_cash",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub total_cash: Option<f64>,
+    /// Buying power.
+    #[serde(
+        rename = "buying_power",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub buying_power: Option<f64>,
+    /// Market value of long positions.
+    #[serde(
+        rename = "long_market_value",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub long_market_value: Option<f64>,
+    /// Market value of short positions.
+    #[serde(
+        rename = "short_market_value",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub short_market_value: Option<f64>,
+}
+
+/// Aggregated trade event (per-symbol, per-side rollup).
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct AccountTradeEvent {
+    /// Account number.
+    #[serde(
+        rename = "account_number",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub account_number: Option<String>,
+    /// Symbol.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub symbol: Option<String>,
+    /// Side (`buy`, `sell`, ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub side: Option<String>,
+    /// Aggregated quantity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quantity: Option<f64>,
+    /// Aggregated volume-weighted average price.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub price: Option<f64>,
+    /// Timestamp.
+    #[serde(
+        rename = "transaction_date",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub transaction_date: Option<String>,
+}
+
+/// Session drop notification.
+///
+/// Tradier emits this when the account stream is terminated — e.g.
+/// session expiry, administrative unsubscribe. Callers should treat
+/// this as a reason to tear down the session and re-bootstrap.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct AccountDropEvent {
+    /// Account number affected by the drop.
+    #[serde(
+        rename = "account_number",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub account_number: Option<String>,
+    /// Free-form reason string, when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+impl AccountEvent {
+    /// Returns the account number attached to the event, if any.
+    #[must_use]
+    #[inline]
+    pub fn account_number(&self) -> Option<&str> {
+        match self {
+            AccountEvent::Order(o) => o.account_number.as_deref(),
+            AccountEvent::Fill(f) => f.account_number.as_deref(),
+            AccountEvent::Position(p) => p.account_number.as_deref(),
+            AccountEvent::Balance(b) => b.account_number.as_deref(),
+            AccountEvent::Trade(t) => t.account_number.as_deref(),
+            AccountEvent::Drop(d) => d.account_number.as_deref(),
+        }
+    }
+
+    /// Parses a single account event from a JSON line.
+    ///
+    /// # Errors
+    /// Returns [`Error::StreamDecodeError`] with the offending payload
+    /// and the underlying `serde_json` error when the JSON does not
+    /// match any known variant.
+    pub fn from_json(line: &str) -> Result<Self> {
+        serde_json::from_str::<Self>(line)
+            .map_err(|e| Error::StreamDecodeError(line.to_owned(), e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_account_event_order_happy_path() {
+        let line = r#"{"event":"order","id":123,"status":"filled","account_number":"VA1234","symbol":"SPY","side":"buy","quantity":100.0,"remaining_quantity":0.0,"executed_quantity":100.0,"avg_fill_price":281.12,"transaction_date":"1557757204760"}"#;
+        let event = AccountEvent::from_json(line).expect("parse");
+        let AccountEvent::Order(order) = event else {
+            panic!("expected order variant");
+        };
+        assert_eq!(order.id, 123);
+        assert_eq!(order.status, "filled");
+        assert_eq!(order.account_number.as_deref(), Some("VA1234"));
+        assert_eq!(order.executed_quantity, Some(100.0));
+    }
+
+    #[test]
+    fn test_account_event_fill_happy_path() {
+        let line = r#"{"event":"fill","order_id":123,"account_number":"VA1234","symbol":"SPY","side":"buy","quantity":50.0,"price":281.12,"transaction_date":"1557757204760"}"#;
+        let event = AccountEvent::from_json(line).expect("parse");
+        let AccountEvent::Fill(fill) = event else {
+            panic!("expected fill variant");
+        };
+        assert_eq!(fill.order_id, Some(123));
+        assert_eq!(fill.quantity, Some(50.0));
+    }
+
+    #[test]
+    fn test_account_event_position_happy_path() {
+        let line = r#"{"event":"position","account_number":"VA1234","symbol":"SPY","quantity":100.0,"cost_basis":28112.0}"#;
+        let event = AccountEvent::from_json(line).expect("parse");
+        let AccountEvent::Position(p) = event else {
+            panic!("expected position variant");
+        };
+        assert_eq!(p.cost_basis, Some(28112.0));
+    }
+
+    #[test]
+    fn test_account_event_balance_happy_path() {
+        let line = r#"{"event":"balance","account_number":"VA1234","total_equity":100000.0,"total_cash":50000.0,"buying_power":75000.0}"#;
+        let event = AccountEvent::from_json(line).expect("parse");
+        let AccountEvent::Balance(b) = event else {
+            panic!("expected balance variant");
+        };
+        assert_eq!(b.total_equity, Some(100000.0));
+    }
+
+    #[test]
+    fn test_account_event_trade_happy_path() {
+        let line = r#"{"event":"trade","account_number":"VA1234","symbol":"SPY","side":"buy","quantity":100.0,"price":281.12}"#;
+        let event = AccountEvent::from_json(line).expect("parse");
+        let AccountEvent::Trade(t) = event else {
+            panic!("expected trade variant");
+        };
+        assert_eq!(t.price, Some(281.12));
+    }
+
+    #[test]
+    fn test_account_event_drop_happy_path() {
+        let line = r#"{"event":"drop","account_number":"VA1234","reason":"session expired"}"#;
+        let event = AccountEvent::from_json(line).expect("parse");
+        let AccountEvent::Drop(d) = event else {
+            panic!("expected drop variant");
+        };
+        assert_eq!(d.reason.as_deref(), Some("session expired"));
+    }
+
+    #[test]
+    fn test_account_event_from_json_unknown_event_returns_decode_error() {
+        let line = r#"{"event":"unknown","id":1}"#;
+        let result = AccountEvent::from_json(line);
+        assert!(matches!(result, Err(Error::StreamDecodeError(_, _))));
+    }
+
+    #[test]
+    fn test_account_event_from_json_malformed_returns_decode_error() {
+        let result = AccountEvent::from_json("not json");
+        assert!(matches!(result, Err(Error::StreamDecodeError(_, _))));
+    }
+
+    #[test]
+    fn test_account_event_account_number_returns_value_when_present() {
+        let order = AccountOrderEvent {
+            id: 1,
+            status: "open".into(),
+            account_number: Some("VA9".into()),
+            symbol: None,
+            side: None,
+            quantity: None,
+            remaining_quantity: None,
+            executed_quantity: None,
+            avg_fill_price: None,
+            last_fill_price: None,
+            last_fill_quantity: None,
+            transaction_date: None,
+        };
+        let event = AccountEvent::Order(order);
+        assert_eq!(event.account_number(), Some("VA9"));
+    }
+}

--- a/src/wssession/market.rs
+++ b/src/wssession/market.rs
@@ -1,12 +1,14 @@
 use crate::config::Config;
+use crate::wssession::events::MarketEvent;
 use crate::wssession::session::{Session, SessionType};
 use crate::{Error, Result};
+use futures_util::stream::Stream;
 use futures_util::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::fmt::{Display, Formatter};
 use tokio_tungstenite::connect_async;
-use tracing::{error, info};
+use tracing::{debug, info, trace, warn};
 use tungstenite::Message;
 use url::Url;
 
@@ -211,61 +213,102 @@ impl<'a> MarketSession<'a> {
         self.0.get_websocket_url()
     }
 
-    /// Initiates a WebSocket connection and streams data based on the provided payload.
+    /// Opens the market WebSocket and returns an async [`Stream`] of typed
+    /// [`MarketEvent`] values.
     ///
-    /// # Arguments
-    /// - `payload`: A `MarketSessionPayload` specifying symbols and settings for the WebSocket session.
+    /// Each upstream text frame is split on `\n` so a single frame that
+    /// happens to bundle multiple newline-delimited JSON events is still
+    /// handled correctly (Tradier's current contract delivers one event
+    /// per frame, but this keeps the decoder future-proof).
     ///
-    /// # Returns
-    /// - `Ok(())`: If the WebSocket connection was successfully managed.
-    /// - `Err(Box<dyn Error>)`: If the WebSocket connection or data streaming fails.
+    /// Decode failures surface as `Err(Error::StreamDecodeError(...))`
+    /// items and do NOT abort the stream — the decoder continues reading
+    /// subsequent frames. Peer-initiated `Close` frames terminate the
+    /// stream without yielding an error. `Ping` frames are answered
+    /// automatically by `tokio_tungstenite`; if the automatic pong send
+    /// fails, the failure is surfaced as `Err(Error::WebSocketError(...))`
+    /// and the stream terminates.
     ///
-    /// # Behavior
-    /// - Connects to the WebSocket endpoint.
-    /// - Sends the specified `MarketSessionPayload`.
-    /// - Listens for incoming messages and logs text or binary data.
-    /// - Terminates on connection close or error.
-    pub async fn ws_stream(&self, payload: MarketSessionPayload<'a>) -> Result<()> {
-        let uri = &self.0.stream_info.url;
+    /// Reconnect policy is the caller's responsibility — see the example
+    /// under `examples/auth_websocket_example.rs`.
+    ///
+    /// # Errors
+    /// - [`Error::UrlParsingError`] if the session URL is malformed.
+    /// - [`Error::WebSocketError`] if the handshake or initial payload
+    ///   send fails.
+    /// - [`Error::JsonParsingError`] if the subscription payload cannot
+    ///   be serialized.
+    ///
+    /// After the stream is established, per-frame errors are yielded as
+    /// `Err(_)` items of the stream rather than aborting early.
+    pub async fn event_stream(
+        &self,
+        payload: MarketSessionPayload<'a>,
+    ) -> Result<impl Stream<Item = Result<MarketEvent>>> {
+        let uri = self.0.get_websocket_url();
         let url = Url::parse(uri)?;
 
-        info!("Connecting to: {}", uri);
+        info!(url = %uri, "connecting to market stream");
         let (ws_stream, _) = connect_async(url.as_str()).await.map_err(Box::new)?;
-        let (mut write, mut read) = ws_stream.split();
+        let (mut write, read) = ws_stream.split();
 
         let message = payload.get_message()?;
         write.send(message).await.map_err(Box::new)?;
-        info!("Sent payload: {}", payload);
+        debug!("sent market subscription payload");
 
-        while let Some(message) = read.next().await {
-            match message {
-                Ok(Message::Text(text)) => {
-                    info!("Received: {}", text);
+        Ok(market_event_stream(read))
+    }
+
+    /// Initiates a WebSocket connection and streams data based on the provided payload.
+    ///
+    /// Kept for back-compat — internally drives [`Self::event_stream`] and
+    /// logs each parsed event at `TRACE`, each decode error at `WARN`.
+    /// Prefer [`Self::event_stream`] for new code.
+    ///
+    /// # Errors
+    /// Same as [`Self::event_stream`].
+    pub async fn ws_stream(&self, payload: MarketSessionPayload<'a>) -> Result<()> {
+        let stream = self.event_stream(payload).await?;
+        futures_util::pin_mut!(stream);
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(event) => {
+                    trace!(symbol = event.symbol(), "market event");
                 }
-                Ok(Message::Binary(data)) => {
-                    info!("Received binary data: {} bytes", data.len());
-                    // Handle binary data as needed
-                }
-                Ok(Message::Close(frame)) => {
-                    info!("Connection closed: {:?}", frame);
-                    break;
+                Err(Error::StreamDecodeError(_, err)) => {
+                    warn!(error = %err, "decode failure on market frame, continuing");
                 }
                 Err(e) => {
-                    error!("Error: {}", e);
-                    break;
+                    warn!(error = %e, "market stream error, terminating");
+                    return Err(e);
                 }
-                _ => {}
             }
         }
-
         Ok(())
     }
+}
+
+/// Internal newline-delimited [`MarketEvent`] decoder over a split
+/// WebSocket read half.
+///
+/// Text frames are split on `\n`, each non-empty line is decoded into a
+/// [`MarketEvent`]. Decode errors are yielded as `Err(_)` items but do
+/// not terminate the stream. `Close` frames end the stream cleanly.
+#[inline]
+fn market_event_stream<S>(read: S) -> impl Stream<Item = Result<MarketEvent>>
+where
+    S: Stream<Item = std::result::Result<Message, tungstenite::Error>> + Unpin,
+{
+    super::ws_decode::ws_event_stream(read, MarketEvent::from_json)
 }
 
 #[cfg(test)]
 mod tests {
     use crate::{
-        utils::tests::{create_test_config, mock_websocket_server},
+        utils::tests::{
+            create_test_config, free_tcp_port, mock_websocket_server, scripted_websocket_server,
+            ScriptedWsAction,
+        },
         wssession::session_manager::SessionManager,
     };
 
@@ -521,5 +564,200 @@ mod tests {
                 );
             }
         }
+    }
+
+    // ===== event_stream tests =====
+    //
+    // These tests stand up a scripted local WebSocket server (no TLS) and
+    // exercise the real framing through `MarketSession::event_stream`.
+
+    const QUOTE_FRAME: &str = r#"{"type":"quote","symbol":"C","bid":281.84,"bidsz":60,"bidexch":"M","biddate":"1557757189000","ask":281.85,"asksz":6,"askexch":"Z","askdate":"1557757190000"}"#;
+    const TRADE_FRAME: &str = r#"{"type":"trade","symbol":"SPY","exch":"Q","price":"281.1200","size":"100","cvol":"34507070","date":"1557757204760","last":"281.1200"}"#;
+    const SUMMARY_FRAME: &str = r#"{"type":"summary","symbol":"SPY","open":"284.01","high":"284.42","low":"280.51","prevClose":"287.59"}"#;
+    const TIMESALE_FRAME: &str = r#"{"type":"timesale","symbol":"SPY","exch":"Q","bid":"281.09","ask":"281.10","last":"281.10","size":"100","date":"1557757204760","seq":352342,"flag":"","cancel":false,"correction":false,"session":"normal"}"#;
+    const TRADEX_FRAME: &str = r#"{"type":"tradex","symbol":"SPY","exch":"Q","price":"281.10","size":"100","cvol":"34507070","date":"1557757204760","last":"281.10"}"#;
+    const MALFORMED_FRAME: &str = r#"{"type":"quote","symbol":"C","bid": not-json"#;
+
+    /// Boots a market session wired to a leaked `SessionManager` and
+    /// `Config` so the returned session satisfies `'static`. Leaking is
+    /// acceptable here — each test is short-lived and owns its own
+    /// `SessionManager`, so there is no cross-test contention.
+    async fn build_market_session_against_port(port: u16) -> MarketSession<'static> {
+        let server = Box::leak(Box::new(Server::new_async().await));
+        let json_data = format!(
+            r#"
+        {{
+            "stream": {{
+                "url": "ws://127.0.0.1:{port}/v1/markets/events",
+                "sessionid": "c8638963-a6d4-4fb9-9bc6-e25fbd8c60c3"
+            }}
+        }}
+        "#
+        );
+        server
+            .mock("POST", "/v1/markets/events/session")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(json_data)
+            .create_async()
+            .await;
+
+        let config = Box::leak(Box::new(
+            create_test_config().server_url(&server.url()).finish(),
+        ));
+        let session_manager: &'static SessionManager =
+            Box::leak(Box::new(SessionManager::default()));
+        MarketSession::new_with_session_manager(config, session_manager)
+            .await
+            .expect("market session")
+    }
+
+    #[tokio::test]
+    async fn test_market_event_stream_yields_typed_events_in_order() {
+        let port = free_tcp_port();
+        let session = build_market_session_against_port(port).await;
+
+        scripted_websocket_server(
+            ("127.0.0.1", port),
+            vec![
+                ScriptedWsAction::SendText(QUOTE_FRAME),
+                ScriptedWsAction::SendText(TRADE_FRAME),
+                ScriptedWsAction::SendText(SUMMARY_FRAME),
+                ScriptedWsAction::SendText(TIMESALE_FRAME),
+                ScriptedWsAction::SendText(TRADEX_FRAME),
+                ScriptedWsAction::SendClose,
+            ],
+            |_subscription_json| {},
+        )
+        .await;
+
+        let symbols = ["SPY".to_string()];
+        let payload = MarketSessionPayload::builder()
+            .symbols(&symbols)
+            .session_id(session.get_session_id())
+            .build();
+
+        let stream = session.event_stream(payload).await.expect("event_stream");
+        let collected: Vec<Result<MarketEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 5, "expected 5 events, got {collected:?}");
+        assert!(matches!(collected[0], Ok(MarketEvent::Quote(_))));
+        assert!(matches!(collected[1], Ok(MarketEvent::Trade(_))));
+        assert!(matches!(collected[2], Ok(MarketEvent::Summary(_))));
+        assert!(matches!(collected[3], Ok(MarketEvent::Timesale(_))));
+        assert!(matches!(collected[4], Ok(MarketEvent::Tradex(_))));
+    }
+
+    #[tokio::test]
+    async fn test_market_event_stream_malformed_frame_yields_decode_error_and_continues() {
+        let port = free_tcp_port();
+        let session = build_market_session_against_port(port).await;
+
+        scripted_websocket_server(
+            ("127.0.0.1", port),
+            vec![
+                ScriptedWsAction::SendText(QUOTE_FRAME),
+                ScriptedWsAction::SendText(MALFORMED_FRAME),
+                ScriptedWsAction::SendText(TRADE_FRAME),
+                ScriptedWsAction::SendClose,
+            ],
+            |_sub| {},
+        )
+        .await;
+
+        let symbols = ["SPY".to_string()];
+        let payload = MarketSessionPayload::builder()
+            .symbols(&symbols)
+            .session_id(session.get_session_id())
+            .build();
+        let stream = session.event_stream(payload).await.expect("event_stream");
+        let collected: Vec<Result<MarketEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 3, "expected 3 items, got {collected:?}");
+        assert!(matches!(collected[0], Ok(MarketEvent::Quote(_))));
+        assert!(matches!(collected[1], Err(Error::StreamDecodeError(_, _))));
+        assert!(matches!(collected[2], Ok(MarketEvent::Trade(_))));
+    }
+
+    #[tokio::test]
+    async fn test_market_event_stream_multiple_events_per_frame_decoded_individually() {
+        let port = free_tcp_port();
+        let session = build_market_session_against_port(port).await;
+
+        // Two events on one line, separated by `\n`.
+        let compound = Box::leak(format!("{}\n{}", QUOTE_FRAME, TRADE_FRAME).into_boxed_str());
+        scripted_websocket_server(
+            ("127.0.0.1", port),
+            vec![
+                ScriptedWsAction::SendText(compound),
+                ScriptedWsAction::SendClose,
+            ],
+            |_sub| {},
+        )
+        .await;
+
+        let symbols = ["SPY".to_string()];
+        let payload = MarketSessionPayload::builder()
+            .symbols(&symbols)
+            .session_id(session.get_session_id())
+            .build();
+        let stream = session.event_stream(payload).await.expect("event_stream");
+        let collected: Vec<Result<MarketEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 2);
+        assert!(matches!(collected[0], Ok(MarketEvent::Quote(_))));
+        assert!(matches!(collected[1], Ok(MarketEvent::Trade(_))));
+    }
+
+    #[tokio::test]
+    async fn test_market_event_stream_peer_close_terminates_without_error() {
+        let port = free_tcp_port();
+        let session = build_market_session_against_port(port).await;
+
+        scripted_websocket_server(
+            ("127.0.0.1", port),
+            vec![
+                ScriptedWsAction::SendText(QUOTE_FRAME),
+                ScriptedWsAction::SendClose,
+            ],
+            |_sub| {},
+        )
+        .await;
+
+        let symbols = ["SPY".to_string()];
+        let payload = MarketSessionPayload::builder()
+            .symbols(&symbols)
+            .session_id(session.get_session_id())
+            .build();
+        let stream = session.event_stream(payload).await.expect("event_stream");
+        let collected: Vec<Result<MarketEvent>> = stream.collect().await;
+        assert_eq!(collected.len(), 1);
+        assert!(collected[0].is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_market_event_stream_ping_is_answered_and_does_not_yield_an_item() {
+        let port = free_tcp_port();
+        let session = build_market_session_against_port(port).await;
+
+        scripted_websocket_server(
+            ("127.0.0.1", port),
+            vec![
+                ScriptedWsAction::SendPing(b"hello"),
+                ScriptedWsAction::SendText(QUOTE_FRAME),
+                ScriptedWsAction::SendClose,
+            ],
+            |_sub| {},
+        )
+        .await;
+
+        let symbols = ["SPY".to_string()];
+        let payload = MarketSessionPayload::builder()
+            .symbols(&symbols)
+            .session_id(session.get_session_id())
+            .build();
+        let stream = session.event_stream(payload).await.expect("event_stream");
+        let collected: Vec<Result<MarketEvent>> = stream.collect().await;
+        // The ping does not surface as a user-visible item; only the
+        // quote does.
+        assert_eq!(collected.len(), 1);
+        assert!(matches!(collected[0], Ok(MarketEvent::Quote(_))));
     }
 }

--- a/src/wssession/mod.rs
+++ b/src/wssession/mod.rs
@@ -9,16 +9,28 @@
 //! ## Overview
 //!
 //! - **`AccountSession`**: Manages WebSocket sessions for streaming account-related events, such as
-//!   order status updates and balance changes.
+//!   order status updates and balance changes. Use
+//!   [`AccountSession::event_stream`] for a typed [`AccountEvent`] stream.
 //! - **`MarketSession`**: Handles WebSocket sessions for streaming market data, including real-time
-//!   quotes and trades.
+//!   quotes and trades. Use [`MarketSession::event_stream`] for a typed
+//!   [`MarketEvent`] stream.
 //! - **`SessionManager`**: Ensures that only one streaming session is active at any given time, adhering
 //!   to Tradier's limitation of a single concurrent session per user.
+//!
+//! ## HTTP streaming fallback
+//!
+//! When WebSockets are not reachable (strict corporate egress, NAT
+//! timeouts, …), Tradier also exposes a parallel **HTTP** chunked
+//! streaming API. See [`crate::streaming::http_stream`] for
+//! `Stream`-returning helpers that reuse the pooled `reqwest::Client`
+//! on a [`crate::client::non_blocking::TradierRestClient`].
 //!
 //! ## Usage
 //!
 //! By utilizing these components, developers can integrate Tradier's streaming capabilities into
-//! their applications, facilitating real-time data processing and event handling.
+//! their applications, facilitating real-time data processing and event handling. Reconnection is
+//! the caller's responsibility — the library exposes the session id, subscription payload, and
+//! the stream itself; the caller drives the retry loop.
 
 mod account;
 pub mod account_events;

--- a/src/wssession/mod.rs
+++ b/src/wssession/mod.rs
@@ -27,6 +27,7 @@ mod market;
 
 pub(crate) mod session;
 pub(crate) mod session_manager;
+pub(crate) mod ws_decode;
 
 pub use account::{AccountSession, AccountSessionEvent, AccountSessionPayload};
 pub use events::{MarketEvent, Quote, Summary, Timesale, Trade, TradeSession, Tradex};

--- a/src/wssession/mod.rs
+++ b/src/wssession/mod.rs
@@ -21,6 +21,7 @@
 //! their applications, facilitating real-time data processing and event handling.
 
 mod account;
+pub mod account_events;
 
 pub mod events;
 mod market;
@@ -30,5 +31,9 @@ pub(crate) mod session_manager;
 pub(crate) mod ws_decode;
 
 pub use account::{AccountSession, AccountSessionEvent, AccountSessionPayload};
+pub use account_events::{
+    AccountBalanceEvent, AccountDropEvent, AccountEvent, AccountFillEvent, AccountOrderEvent,
+    AccountPositionEvent, AccountTradeEvent,
+};
 pub use events::{MarketEvent, Quote, Summary, Timesale, Trade, TradeSession, Tradex};
 pub use market::{MarketSession, MarketSessionFilter, MarketSessionPayload};

--- a/src/wssession/ws_decode.rs
+++ b/src/wssession/ws_decode.rs
@@ -1,0 +1,103 @@
+//! Shared newline-delimited JSON decoder over a WebSocket read half.
+//!
+//! Both [`crate::wssession::MarketSession`] and
+//! [`crate::wssession::AccountSession`] use this plumbing to turn a
+//! `Stream<Item = tungstenite::Result<Message>>` into a
+//! `Stream<Item = Result<T>>` where `T` is a typed event.
+//!
+//! The decoder:
+//! - Splits `Message::Text` (and `Message::Binary`, after lossy UTF-8
+//!   conversion) frames on `\n` and feeds each non-empty line through
+//!   the caller-provided `decode` function.
+//! - Yields decode failures as `Err(Error::StreamDecodeError(_, _))`
+//!   items; it does NOT abort the stream on a decode failure.
+//! - Treats `Message::Close` as end-of-stream (no error yielded).
+//! - Treats transport errors as `Err(Error::WebSocketError(_))` items
+//!   and then ends the stream.
+//! - Ignores `Ping`, `Pong`, and raw `Frame` messages;
+//!   `tokio_tungstenite` handles the automatic `Pong` reply.
+
+use futures_util::stream::{self, Stream, StreamExt};
+use std::collections::VecDeque;
+use tracing::warn;
+use tungstenite::Message;
+
+use crate::Result;
+
+/// State carried across calls to [`stream::unfold`].
+struct DecoderState<S, T, F> {
+    read: S,
+    pending: VecDeque<Result<T>>,
+    decode: F,
+    finished: bool,
+}
+
+/// Drives a WebSocket read half and yields decoded events.
+///
+/// `decode` is applied to every non-empty, newline-separated JSON line
+/// from a `Message::Text` (or `Message::Binary`) frame.
+#[inline]
+pub(super) fn ws_event_stream<S, T, F>(read: S, decode: F) -> impl Stream<Item = Result<T>>
+where
+    S: Stream<Item = std::result::Result<Message, tungstenite::Error>> + Unpin,
+    F: Fn(&str) -> Result<T>,
+{
+    let state = DecoderState {
+        read,
+        pending: VecDeque::new(),
+        decode,
+        finished: false,
+    };
+
+    stream::unfold(state, |mut state| async move {
+        loop {
+            if let Some(item) = state.pending.pop_front() {
+                return Some((item, state));
+            }
+            if state.finished {
+                return None;
+            }
+            match state.read.next().await {
+                Some(Ok(Message::Text(text))) => {
+                    push_lines(&mut state.pending, text.as_ref(), &state.decode);
+                }
+                Some(Ok(Message::Binary(bytes))) => {
+                    let text = String::from_utf8_lossy(bytes.as_ref());
+                    push_lines(&mut state.pending, text.as_ref(), &state.decode);
+                }
+                Some(Ok(Message::Close(_))) => {
+                    state.finished = true;
+                }
+                Some(Ok(Message::Ping(_)))
+                | Some(Ok(Message::Pong(_)))
+                | Some(Ok(Message::Frame(_))) => {
+                    // tokio-tungstenite answers pings automatically; no work.
+                }
+                Some(Err(e)) => {
+                    warn!(error = %e, "websocket transport error, terminating stream");
+                    state.finished = true;
+                    state
+                        .pending
+                        .push_back(Err(crate::Error::WebSocketError(Box::new(e))));
+                }
+                None => {
+                    state.finished = true;
+                }
+            }
+        }
+    })
+}
+
+#[inline]
+fn push_lines<T, F>(out: &mut VecDeque<Result<T>>, text: &str, decode: &F)
+where
+    F: Fn(&str) -> Result<T>,
+{
+    for line in text.split('\n') {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        out.push_back(decode(trimmed));
+    }
+}


### PR DESCRIPTION
## Summary

Finishes issue #11 end-to-end: typed market and account WebSocket event
emission, plus the HTTP chunked-transfer fallback. Built on top of
PR #27 (event types) and PR #28 (account session).

### A. Market WebSocket event emission

- New `MarketSession::event_stream(payload) -> impl Stream<Item = Result<MarketEvent>>`
  emits typed `MarketEvent` values using a shared newline-delimited
  decoder under `wssession::ws_decode`.
- `ws_stream` kept for back-compat — now drives `event_stream`
  internally and logs only at `TRACE` / `WARN`.
- Multiple newline-separated events per frame are decoded as separate
  items.
- Decode failures surface as `Err(Error::StreamDecodeError(_, _))` and
  do NOT abort the stream.
- Peer `Close` ends the stream cleanly. `Ping` frames are answered
  automatically by `tokio_tungstenite`.

### B. Account WebSocket event emission

- New `wssession::account_events` module: `AccountEvent` tagged on
  the `event` field, with six documented variants (`order`, `fill`,
  `position`, `balance`, `trade`, `drop`) marked `#[non_exhaustive]`.
- New `AccountSession::event_stream(payload) -> impl Stream<Item = Result<AccountEvent>>`
  with the same error / ping / close policy as the market side.
- `ws_stream` kept for back-compat; account numbers are never logged
  in clear.

### C. HTTP streaming (chunked-transfer fallback)

- New `streaming::http_stream::market_events` and
  `streaming::http_stream::account_events` — `Stream`-returning
  helpers that reuse the pooled `reqwest::Client` on the existing
  `TradierRestClient` (no per-call client construction).
- Non-2xx HTTP status surfaces as `Error::NetworkError`
  synchronously, before the stream is constructed.
- Per-line decode failures surface as
  `Err(Error::StreamDecodeError(_, _))` without aborting the stream.
- `reqwest` gains the `stream` feature (required for
  `Response::bytes_stream()`). No new crates added.

### D. Docs + example

- `wssession::mod` doc now cross-links to `streaming::http_stream`.
- README gains a short "HTTP streaming" paragraph under the existing
  WebSocket example.
- New runnable example under `examples/http_stream_market/` mirroring
  `examples/non_blocking_client/`.

## Test matrix

All tests hermetic, all deterministic, all well under 2 s each.

| Scenario | Covered by |
| --- | --- |
| Market WS: ordered `quote`/`trade`/`summary`/`timesale`/`tradex` | `test_market_event_stream_yields_typed_events_in_order` |
| Market WS: malformed frame yields decode error and stream continues | `test_market_event_stream_malformed_frame_yields_decode_error_and_continues` |
| Market WS: multiple events per frame decoded individually | `test_market_event_stream_multiple_events_per_frame_decoded_individually` |
| Market WS: peer `Close` terminates cleanly | `test_market_event_stream_peer_close_terminates_without_error` |
| Market WS: `Ping` is answered, no user-visible item | `test_market_event_stream_ping_is_answered_and_does_not_yield_an_item` |
| Account WS: ordered six-variant emission | `test_account_event_stream_yields_typed_events_in_order` |
| Account WS: malformed frame continues | `test_account_event_stream_malformed_frame_yields_decode_error_and_continues` |
| Account WS: peer `Close` terminates cleanly | `test_account_event_stream_peer_close_terminates_without_error` |
| Account event types: all six variants + unknown + malformed | 9 tests in `wssession::account_events::tests` |
| HTTP market: newline-delimited decode happy path | `test_http_market_stream_decodes_newline_delimited_events` |
| HTTP market: malformed line continuation | `test_http_market_stream_malformed_line_yields_decode_error_and_continues` |
| HTTP market: non-2xx surfaces `NetworkError` | `test_http_market_stream_non_success_surfaces_network_error` |
| HTTP account: same three scenarios | 3 tests in `streaming::http_stream::tests` |

## Pre-submission gates

All green:

```
cargo build --release                         # OK (zero warnings)
cargo clippy --all-targets --all-features -- -D warnings   # OK
cargo fmt --all --check                       # OK
cargo test --all-features                     # 109 passed; 0 failed (+ 6 doctests)
```

Commits:
1. `feat(wssession): add MarketSession::event_stream`
2. `feat(wssession): add account event response types`
3. `feat(wssession): add AccountSession::event_stream`
4. `feat(streaming): add HTTP market event stream`
5. `feat(streaming): add HTTP account event stream`
6. `docs(streaming): update README + module docs + example`

Related: PR #27 (event types), PR #28 (account session).

Closes #11