### PR TITLE
feat(fundamentals): implement REST endpoints (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ The library leverages Rust's performance and concurrency advantages, making it s
 2. **Real-time Market Data**: Access live quotes, option chains, historical OHLCV bars,
    intraday time-and-sales, market clock / calendar, and ETB / lookup / search endpoints
    via typed REST bindings (`MarketData` trait).
+3. **Fundamentals (beta)**: Company profiles, corporate calendars (earnings / IPOs),
+   dividend history, corporate actions (splits / mergers), financial ratios (P/E,
+   EPS, margins), income / balance / cash-flow statements, and price statistics
+   via the `Fundamentals` trait. See `examples/fundamentals_company/main.rs`.
 3. **Portfolio Management**: Retrieve account information, positions, and performance metrics.
 4. **Historical Data**: Fetch and analyze historical price and volume data.
 5. **Streaming Data**: Utilize WebSocket connections for real-time data feeds.

--- a/examples/fundamentals_company/main.rs
+++ b/examples/fundamentals_company/main.rs
@@ -1,0 +1,44 @@
+//! Example demonstrating the Tradier Fundamentals (beta) REST endpoints.
+//!
+//! Run with:
+//!
+//! ```text
+//! TRADIER_ACCESS_TOKEN=... \
+//! cargo run --example fundamentals_company
+//! ```
+//!
+//! Set `TRADIER_REST_BASE_URL` to `https://sandbox.tradier.com` to point at
+//! the sandbox instead of production.
+
+use tracing::info;
+use tradier::non_blocking::operation::Fundamentals;
+use tradier::non_blocking::Client;
+use tradier::types::Symbol;
+use tradier::utils::logger::setup_logger;
+use tradier::Config;
+
+#[tokio::main]
+async fn main() -> std::result::Result<(), Box<dyn core::error::Error>> {
+    setup_logger();
+
+    let config = Config::new();
+    info!("Config: {:?}", &config);
+
+    let client = Client::new(config);
+
+    let symbols = ["AAPL".parse::<Symbol>()?, "MSFT".parse::<Symbol>()?];
+
+    // Company profile and share-class info.
+    let company = client.get_company(&symbols).await?;
+    info!("Company response: {:#?}", company);
+
+    // Dividend history.
+    let dividends = client.get_dividends(&symbols).await?;
+    info!("Dividends response: {:#?}", dividends);
+
+    // Price statistics.
+    let statistics = client.get_statistics(&symbols).await?;
+    info!("Statistics response: {:#?}", statistics);
+
+    Ok(())
+}

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -31,6 +31,14 @@ use crate::{
     accounts::{api::blocking::Accounts, api::non_blocking::Accounts as NonBlockingAccounts},
     client::non_blocking::TradierRestClient as AsyncClient,
     common::SortOrder,
+    fundamentals::{
+        api::blocking::Fundamentals,
+        api::non_blocking::Fundamentals as NonBlockingFundamentals,
+        types::{
+            CompanyResponse, CorporateActionResponse, CorporateCalendarResponse, DividendResponse,
+            FinancialsResponse, RatiosResponse, StatisticsResponse,
+        },
+    },
     market_data::{
         api::blocking::MarketData,
         api::non_blocking::MarketData as NonBlockingMarketData,
@@ -309,6 +317,49 @@ impl MarketData for BlockingTradierRestClient {
     ) -> Result<LookupSymbolResponse> {
         self.runtime
             .block_on(self.rest_client.lookup_symbol(q, exchanges, types))
+    }
+}
+
+impl Fundamentals for BlockingTradierRestClient {
+    fn get_company(&self, symbols: &[Symbol]) -> Result<Vec<CompanyResponse>> {
+        self.runtime
+            .block_on(self.rest_client.get_company(symbols))
+    }
+
+    fn get_corporate_calendars(
+        &self,
+        symbols: &[Symbol],
+    ) -> Result<Vec<CorporateCalendarResponse>> {
+        self.runtime
+            .block_on(self.rest_client.get_corporate_calendars(symbols))
+    }
+
+    fn get_dividends(&self, symbols: &[Symbol]) -> Result<Vec<DividendResponse>> {
+        self.runtime
+            .block_on(self.rest_client.get_dividends(symbols))
+    }
+
+    fn get_corporate_actions(
+        &self,
+        symbols: &[Symbol],
+    ) -> Result<Vec<CorporateActionResponse>> {
+        self.runtime
+            .block_on(self.rest_client.get_corporate_actions(symbols))
+    }
+
+    fn get_ratios(&self, symbols: &[Symbol]) -> Result<Vec<RatiosResponse>> {
+        self.runtime
+            .block_on(self.rest_client.get_ratios(symbols))
+    }
+
+    fn get_financials(&self, symbols: &[Symbol]) -> Result<Vec<FinancialsResponse>> {
+        self.runtime
+            .block_on(self.rest_client.get_financials(symbols))
+    }
+
+    fn get_statistics(&self, symbols: &[Symbol]) -> Result<Vec<StatisticsResponse>> {
+        self.runtime
+            .block_on(self.rest_client.get_statistics(symbols))
     }
 }
 
@@ -1339,6 +1390,496 @@ mod market_data_tests {
         cfg.rest_api.base_url = "http://127.0.0.1:1".into();
         let client = BlockingTradierRestClient::new(cfg).expect("client");
         let resp = client.get_etb_securities();
+        assert!(resp.is_err());
+    }
+}
+
+#[cfg(test)]
+mod fundamentals_tests {
+    use super::BlockingTradierRestClient;
+    use crate::{
+        common::Symbol,
+        fundamentals::{
+            api::blocking::Fundamentals,
+            test_support::{
+                CompanyResponseArrayWire, CorporateActionResponseArrayWire,
+                CorporateCalendarResponseArrayWire, DividendResponseArrayWire,
+                FinancialsResponseArrayWire, RatiosResponseArrayWire, StatisticsResponseArrayWire,
+            },
+        },
+        utils::tests::with_env_vars,
+        Config,
+    };
+    use httpmock::MockServer;
+    use proptest::prelude::*;
+    use std::cell::RefCell;
+
+    fn make_symbol(s: &str) -> Symbol {
+        s.parse().expect("valid symbol")
+    }
+
+    fn make_client(server: &MockServer) -> BlockingTradierRestClient {
+        let mut cfg = Config::new();
+        cfg.rest_api.base_url = server.base_url();
+        BlockingTradierRestClient::new(cfg).expect("client to initialize")
+    }
+
+    fn run_with_env<F: FnOnce()>(server: &MockServer, f: F) {
+        with_env_vars(
+            vec![
+                ("TRADIER_REST_BASE_URL", &server.base_url()),
+                ("TRADIER_ACCESS_TOKEN", "testToken"),
+            ],
+            f,
+        );
+    }
+
+    // -------- get_company -----------------------------------------------
+
+    #[test]
+    fn test_get_company_happy_path_verifies_query_and_header() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(wire in any::<CompanyResponseArrayWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/beta/markets/fundamentals/company")
+                        .header("accept", "application/json")
+                        .query_param("symbols", "AAPL,MSFT");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&wire).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_company(&[make_symbol("AAPL"), make_symbol("MSFT")]);
+                    op.assert();
+                    assert!(resp.is_ok(), "resp: {:?}", resp.err());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_company_bad_request_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/company");
+            then.status(400)
+                .header("content-type", "application/json")
+                .body(r#"{"fault":{"faultstring":"bad"}}"#);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_company(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_company_server_error_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/company");
+            then.status(500);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_company(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_company_malformed_body_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/company");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{ not-json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_company(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // -------- get_corporate_calendars -----------------------------------
+
+    #[test]
+    fn test_get_corporate_calendars_happy_path_verifies_query_and_header() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(wire in any::<CorporateCalendarResponseArrayWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/beta/markets/fundamentals/corporate_calendars")
+                        .header("accept", "application/json")
+                        .query_param("symbols", "AAPL");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&wire).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_corporate_calendars(&[make_symbol("AAPL")]);
+                    op.assert();
+                    assert!(resp.is_ok(), "resp: {:?}", resp.err());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_corporate_calendars_server_error_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/corporate_calendars");
+            then.status(503);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_corporate_calendars(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_corporate_calendars_malformed_body_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/corporate_calendars");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("{ not-json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_corporate_calendars(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // -------- get_dividends ---------------------------------------------
+
+    #[test]
+    fn test_get_dividends_happy_path_verifies_query_and_header() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(wire in any::<DividendResponseArrayWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/beta/markets/fundamentals/dividends")
+                        .header("accept", "application/json")
+                        .query_param("symbols", "AAPL,MSFT");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&wire).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client
+                        .get_dividends(&[make_symbol("AAPL"), make_symbol("MSFT")]);
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_dividends_unauthorized_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/dividends");
+            then.status(401);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_dividends(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_dividends_malformed_body_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/dividends");
+            then.status(200).body("{ not-json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_dividends(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // -------- get_corporate_actions -------------------------------------
+
+    #[test]
+    fn test_get_corporate_actions_happy_path_verifies_query_and_header() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(wire in any::<CorporateActionResponseArrayWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/beta/markets/fundamentals/corporate_actions")
+                        .header("accept", "application/json")
+                        .query_param("symbols", "AAPL");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&wire).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_corporate_actions(&[make_symbol("AAPL")]);
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_corporate_actions_bad_request_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/corporate_actions");
+            then.status(400);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_corporate_actions(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_corporate_actions_malformed_body_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/corporate_actions");
+            then.status(200).body("{ not-json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_corporate_actions(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // -------- get_ratios ------------------------------------------------
+
+    #[test]
+    fn test_get_ratios_happy_path_verifies_query_and_header() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(wire in any::<RatiosResponseArrayWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/beta/markets/fundamentals/ratios")
+                        .header("accept", "application/json")
+                        .query_param("symbols", "AAPL");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&wire).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_ratios(&[make_symbol("AAPL")]);
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_ratios_server_error_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/ratios");
+            then.status(500);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_ratios(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_ratios_malformed_body_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/ratios");
+            then.status(200).body("{ not-json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_ratios(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // -------- get_financials --------------------------------------------
+
+    #[test]
+    fn test_get_financials_happy_path_verifies_query_and_header() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(wire in any::<FinancialsResponseArrayWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/beta/markets/fundamentals/financials")
+                        .header("accept", "application/json")
+                        .query_param("symbols", "AAPL");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&wire).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_financials(&[make_symbol("AAPL")]);
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_financials_server_error_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/financials");
+            then.status(502);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_financials(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_financials_malformed_body_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/financials");
+            then.status(200).body("{ not-json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_financials(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    // -------- get_statistics --------------------------------------------
+
+    #[test]
+    fn test_get_statistics_happy_path_verifies_query_and_header() {
+        let server = RefCell::new(MockServer::start());
+        proptest!(
+            ProptestConfig::with_cases(8),
+            |(wire in any::<StatisticsResponseArrayWire>())| {
+                let server = server.borrow_mut();
+                let mut op = server.mock(|when, then| {
+                    when.method(httpmock::Method::GET)
+                        .path("/beta/markets/fundamentals/statistics")
+                        .header("accept", "application/json")
+                        .query_param("symbols", "AAPL,MSFT,SPY");
+                    then.status(200)
+                        .header("content-type", "application/json")
+                        .body(serde_json::to_vec(&wire).expect("serialize"));
+                });
+                run_with_env(&server, || {
+                    let client = make_client(&server);
+                    let resp = client.get_statistics(&[
+                        make_symbol("AAPL"),
+                        make_symbol("MSFT"),
+                        make_symbol("SPY"),
+                    ]);
+                    op.assert();
+                    assert!(resp.is_ok());
+                });
+                op.delete();
+            }
+        );
+    }
+
+    #[test]
+    fn test_get_statistics_server_error_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/statistics");
+            then.status(500);
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_statistics(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_get_statistics_malformed_body_returns_error() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.path("/beta/markets/fundamentals/statistics");
+            then.status(200).body("{ not-json");
+        });
+        run_with_env(&server, || {
+            let client = make_client(&server);
+            let resp = client.get_statistics(&[make_symbol("AAPL")]);
+            assert!(resp.is_err());
+            op.assert();
+        });
+    }
+
+    #[test]
+    fn test_network_error_when_server_refuses_connection_fundamentals() {
+        let mut cfg = Config::new();
+        cfg.credentials.access_token = Some("t".into());
+        cfg.rest_api.base_url = "http://127.0.0.1:1".into();
+        let client = BlockingTradierRestClient::new(cfg).expect("client");
+        let resp = client.get_company(&[make_symbol("AAPL")]);
         assert!(resp.is_err());
     }
 }

--- a/src/client/blocking.rs
+++ b/src/client/blocking.rs
@@ -322,8 +322,7 @@ impl MarketData for BlockingTradierRestClient {
 
 impl Fundamentals for BlockingTradierRestClient {
     fn get_company(&self, symbols: &[Symbol]) -> Result<Vec<CompanyResponse>> {
-        self.runtime
-            .block_on(self.rest_client.get_company(symbols))
+        self.runtime.block_on(self.rest_client.get_company(symbols))
     }
 
     fn get_corporate_calendars(
@@ -339,17 +338,13 @@ impl Fundamentals for BlockingTradierRestClient {
             .block_on(self.rest_client.get_dividends(symbols))
     }
 
-    fn get_corporate_actions(
-        &self,
-        symbols: &[Symbol],
-    ) -> Result<Vec<CorporateActionResponse>> {
+    fn get_corporate_actions(&self, symbols: &[Symbol]) -> Result<Vec<CorporateActionResponse>> {
         self.runtime
             .block_on(self.rest_client.get_corporate_actions(symbols))
     }
 
     fn get_ratios(&self, symbols: &[Symbol]) -> Result<Vec<RatiosResponse>> {
-        self.runtime
-            .block_on(self.rest_client.get_ratios(symbols))
+        self.runtime.block_on(self.rest_client.get_ratios(symbols))
     }
 
     fn get_financials(&self, symbols: &[Symbol]) -> Result<Vec<FinancialsResponse>> {

--- a/src/client/non_blocking.rs
+++ b/src/client/non_blocking.rs
@@ -11,6 +11,13 @@ use crate::{
     },
     common::SortOrder,
     config::Config,
+    fundamentals::{
+        api::non_blocking::Fundamentals,
+        types::{
+            CompanyResponse, CorporateActionResponse, CorporateCalendarResponse, DividendResponse,
+            FinancialsResponse, RatiosResponse, StatisticsResponse,
+        },
+    },
     market_data::{
         api::non_blocking::MarketData,
         types::{
@@ -500,5 +507,158 @@ impl MarketData for TradierRestClient {
             .json::<LookupSymbolResponse>()
             .await
             .map_err(Error::NetworkError)
+    }
+}
+
+// -----------------------------------------------------------------------------
+// Fundamentals (beta) impl
+// -----------------------------------------------------------------------------
+
+impl TradierRestClient {
+    /// Shared helper for fundamentals endpoints: build the URL with the CSV
+    /// `symbols` query param and GET/parse the JSON array response.
+    async fn get_fundamentals_array<T>(&self, path: &str, symbols: &[Symbol]) -> Result<Vec<T>>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        let mut url = self.get_request_url(path)?;
+        url.query_pairs_mut()
+            .append_pair("symbols", &symbols_to_csv(symbols));
+        let bearer = self.get_bearer_token()?;
+        self.make_service_call(url, bearer)
+            .await?
+            .json::<Vec<T>>()
+            .await
+            .map_err(Error::NetworkError)
+    }
+}
+
+/// Render a slice of [`Symbol`] as a comma-separated CSV, as required by
+/// all fundamentals endpoints.
+#[inline]
+fn symbols_to_csv(symbols: &[Symbol]) -> String {
+    let mut out = String::with_capacity(symbols.len() * 6);
+    for (i, s) in symbols.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str(s.as_str());
+    }
+    out
+}
+
+#[async_trait::async_trait]
+impl Fundamentals for TradierRestClient {
+    async fn get_company(&self, symbols: &[Symbol]) -> Result<Vec<CompanyResponse>> {
+        self.get_fundamentals_array("/beta/markets/fundamentals/company", symbols)
+            .await
+    }
+
+    async fn get_corporate_calendars(
+        &self,
+        symbols: &[Symbol],
+    ) -> Result<Vec<CorporateCalendarResponse>> {
+        self.get_fundamentals_array("/beta/markets/fundamentals/corporate_calendars", symbols)
+            .await
+    }
+
+    async fn get_dividends(&self, symbols: &[Symbol]) -> Result<Vec<DividendResponse>> {
+        self.get_fundamentals_array("/beta/markets/fundamentals/dividends", symbols)
+            .await
+    }
+
+    async fn get_corporate_actions(
+        &self,
+        symbols: &[Symbol],
+    ) -> Result<Vec<CorporateActionResponse>> {
+        self.get_fundamentals_array("/beta/markets/fundamentals/corporate_actions", symbols)
+            .await
+    }
+
+    async fn get_ratios(&self, symbols: &[Symbol]) -> Result<Vec<RatiosResponse>> {
+        self.get_fundamentals_array("/beta/markets/fundamentals/ratios", symbols)
+            .await
+    }
+
+    async fn get_financials(&self, symbols: &[Symbol]) -> Result<Vec<FinancialsResponse>> {
+        self.get_fundamentals_array("/beta/markets/fundamentals/financials", symbols)
+            .await
+    }
+
+    async fn get_statistics(&self, symbols: &[Symbol]) -> Result<Vec<StatisticsResponse>> {
+        self.get_fundamentals_array("/beta/markets/fundamentals/statistics", symbols)
+            .await
+    }
+}
+
+#[cfg(test)]
+mod fundamentals_tests {
+    use super::*;
+    use crate::{
+        fundamentals::api::non_blocking::Fundamentals as NonBlockingFundamentals,
+        utils::tests::with_env_vars, Config,
+    };
+    use httpmock::MockServer;
+
+    fn make_symbol(s: &str) -> Symbol {
+        s.parse().expect("valid symbol")
+    }
+
+    fn make_client(server: &MockServer) -> TradierRestClient {
+        let mut cfg = Config::new();
+        cfg.rest_api.base_url = server.base_url();
+        TradierRestClient::new(cfg)
+    }
+
+    fn run_with_env<F: FnOnce()>(server: &MockServer, f: F) {
+        with_env_vars(
+            vec![
+                ("TRADIER_REST_BASE_URL", &server.base_url()),
+                ("TRADIER_ACCESS_TOKEN", "testToken"),
+            ],
+            f,
+        );
+    }
+
+    #[test]
+    fn test_symbols_to_csv_joins_ascii_symbols() {
+        let v = [make_symbol("AAPL"), make_symbol("MSFT"), make_symbol("SPY")];
+        assert_eq!(symbols_to_csv(&v), "AAPL,MSFT,SPY");
+    }
+
+    #[test]
+    fn test_symbols_to_csv_empty_slice_returns_empty() {
+        assert_eq!(symbols_to_csv(&[]), "");
+    }
+
+    // These are stripped-down smoke tests for the async client. The
+    // blocking client file exercises the full happy/4xx/5xx/malformed
+    // matrix for each of the seven endpoints.
+    #[test]
+    fn test_get_company_builds_expected_request() {
+        let server = MockServer::start();
+        let op = server.mock(|when, then| {
+            when.method(httpmock::Method::GET)
+                .path("/beta/markets/fundamentals/company")
+                .header("accept", "application/json")
+                .query_param("symbols", "AAPL,MSFT");
+            then.status(200)
+                .header("content-type", "application/json")
+                .body("[]");
+        });
+        run_with_env(&server, || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("runtime");
+            rt.block_on(async {
+                let client = make_client(&server);
+                let resp = client
+                    .get_company(&[make_symbol("AAPL"), make_symbol("MSFT")])
+                    .await;
+                assert!(resp.is_ok());
+            });
+            op.assert();
+        });
     }
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use serde::Deserialize;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
@@ -24,6 +26,92 @@ impl std::fmt::Display for SortOrder {
     }
 }
 
+/// A ticker symbol (equity, option, index, etc.).
+///
+/// Tradier symbols are ASCII printable strings; this wrapper validates the
+/// input and rejects empty / blank values.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct Symbol(String);
+
+impl Symbol {
+    /// Returns the inner string slice.
+    #[inline]
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl FromStr for Symbol {
+    type Err = crate::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.trim().is_empty() {
+            Err(crate::Error::MarketDataParseError(format!(
+                "invalid symbol: '{s}' must not be empty or blank"
+            )))
+        } else if s.chars().all(|c| (0x20u8..0x7fu8).contains(&(c as u8))) {
+            Ok(Self(s.to_string()))
+        } else {
+            Err(crate::Error::MarketDataParseError(format!(
+                "invalid symbol: '{s}' must be printable ASCII"
+            )))
+        }
+    }
+}
+
+impl std::fmt::Display for Symbol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Comma-separated collection of [`Symbol`]s used by multi-symbol endpoints.
+#[derive(Clone, Debug, Default, PartialEq)]
+pub struct Symbols(Vec<Symbol>);
+
+impl Symbols {
+    /// Creates a new [`Symbols`] from an iterator of [`Symbol`].
+    #[must_use]
+    pub fn new(symbols: impl IntoIterator<Item = Symbol>) -> Self {
+        Self(symbols.into_iter().collect())
+    }
+
+    /// Returns the inner slice of [`Symbol`] values.
+    #[inline]
+    #[must_use]
+    pub fn as_slice(&self) -> &[Symbol] {
+        &self.0
+    }
+
+    /// Returns `true` if no symbols have been added.
+    #[inline]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl<'a> From<&'a [Symbol]> for Symbols {
+    fn from(value: &'a [Symbol]) -> Self {
+        Self(value.to_vec())
+    }
+}
+
+impl std::fmt::Display for Symbols {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut first = true;
+        for s in &self.0 {
+            if !first {
+                f.write_str(",")?;
+            }
+            f.write_str(s.as_str())?;
+            first = false;
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 pub mod test_support {
     use serde::Serialize;
@@ -33,5 +121,58 @@ pub mod test_support {
     pub enum AccountTypeWire {
         Cash,
         Margin,
+    }
+}
+
+#[cfg(test)]
+mod symbol_tests {
+    use super::*;
+
+    #[test]
+    fn test_symbol_empty_should_error() {
+        let result: Result<Symbol, _> = "".parse();
+        assert!(result.is_err());
+        let result: Result<Symbol, _> = "   ".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_symbol_valid_should_succeed() {
+        let result: Result<Symbol, _> = "AAPL".parse();
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().as_str(), "AAPL");
+    }
+
+    #[test]
+    fn test_symbol_rejects_non_ascii() {
+        let result: Result<Symbol, _> = "BAD\u{80}".parse();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_symbols_display_comma_separated() {
+        let syms = Symbols::new(vec![
+            "AAPL".parse().unwrap(),
+            "MSFT".parse().unwrap(),
+            "GOOG".parse().unwrap(),
+        ]);
+        assert_eq!(syms.to_string(), "AAPL,MSFT,GOOG");
+    }
+
+    #[test]
+    fn test_symbols_empty_display() {
+        let syms = Symbols::default();
+        assert_eq!(syms.to_string(), "");
+        assert!(syms.is_empty());
+    }
+
+    #[test]
+    fn test_symbols_from_slice() {
+        let arr = [
+            "AAPL".parse::<Symbol>().unwrap(),
+            "MSFT".parse::<Symbol>().unwrap(),
+        ];
+        let syms: Symbols = (&arr[..]).into();
+        assert_eq!(syms.to_string(), "AAPL,MSFT");
     }
 }

--- a/src/fundamentals/api.rs
+++ b/src/fundamentals/api.rs
@@ -1,0 +1,133 @@
+//! Traits exposing the Fundamentals (beta) REST endpoints, in both blocking
+//! and non-blocking flavors.
+//!
+//! Upstream documentation:
+//! <https://documentation.tradier.com/brokerage-api/markets/get-company>.
+
+use crate::fundamentals::types::{
+    CompanyResponse, CorporateActionResponse, CorporateCalendarResponse, DividendResponse,
+    FinancialsResponse, RatiosResponse, StatisticsResponse, Symbol,
+};
+use crate::{error::Result, utils::Sealed};
+
+pub mod non_blocking {
+    use super::*;
+
+    /// The non-blocking (async) surface of the Tradier Fundamentals (beta)
+    /// REST API. Every method accepts a slice of [`Symbol`]s and returns a
+    /// vector of endpoint-specific response envelopes — one per requested
+    /// symbol.
+    #[async_trait::async_trait]
+    pub trait Fundamentals: Sealed {
+        /// `GET /beta/markets/fundamentals/company` — company profile and
+        /// share-class details for one or more symbols.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_company(&self, symbols: &[Symbol]) -> Result<Vec<CompanyResponse>>;
+
+        /// `GET /beta/markets/fundamentals/corporate_calendars` — corporate
+        /// event calendars (earnings, IPOs, splits, ...) for one or more symbols.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_corporate_calendars(
+            &self,
+            symbols: &[Symbol],
+        ) -> Result<Vec<CorporateCalendarResponse>>;
+
+        /// `GET /beta/markets/fundamentals/dividends` — dividend history for
+        /// one or more symbols.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_dividends(&self, symbols: &[Symbol]) -> Result<Vec<DividendResponse>>;
+
+        /// `GET /beta/markets/fundamentals/corporate_actions` — corporate
+        /// actions (splits, mergers, spinoffs) for one or more symbols.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_corporate_actions(
+            &self,
+            symbols: &[Symbol],
+        ) -> Result<Vec<CorporateActionResponse>>;
+
+        /// `GET /beta/markets/fundamentals/ratios` — financial ratios (P/E,
+        /// EPS, margins) for one or more symbols.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_ratios(&self, symbols: &[Symbol]) -> Result<Vec<RatiosResponse>>;
+
+        /// `GET /beta/markets/fundamentals/financials` — quarterly / annual
+        /// financial reports (balance sheet, income, cash flow) for one or
+        /// more symbols.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_financials(&self, symbols: &[Symbol]) -> Result<Vec<FinancialsResponse>>;
+
+        /// `GET /beta/markets/fundamentals/statistics` — price statistics
+        /// (averages, volatility, trailing returns) for one or more symbols.
+        ///
+        /// # Errors
+        /// Returns [`crate::Error::NetworkError`] on transport / HTTP failures.
+        async fn get_statistics(&self, symbols: &[Symbol]) -> Result<Vec<StatisticsResponse>>;
+    }
+}
+
+pub mod blocking {
+    use super::*;
+
+    /// The blocking surface of the Tradier Fundamentals (beta) REST API.
+    pub trait Fundamentals: Sealed {
+        /// See [`super::non_blocking::Fundamentals::get_company`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::Fundamentals::get_company`].
+        fn get_company(&self, symbols: &[Symbol]) -> Result<Vec<CompanyResponse>>;
+
+        /// See [`super::non_blocking::Fundamentals::get_corporate_calendars`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::Fundamentals::get_corporate_calendars`].
+        fn get_corporate_calendars(
+            &self,
+            symbols: &[Symbol],
+        ) -> Result<Vec<CorporateCalendarResponse>>;
+
+        /// See [`super::non_blocking::Fundamentals::get_dividends`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::Fundamentals::get_dividends`].
+        fn get_dividends(&self, symbols: &[Symbol]) -> Result<Vec<DividendResponse>>;
+
+        /// See [`super::non_blocking::Fundamentals::get_corporate_actions`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::Fundamentals::get_corporate_actions`].
+        fn get_corporate_actions(
+            &self,
+            symbols: &[Symbol],
+        ) -> Result<Vec<CorporateActionResponse>>;
+
+        /// See [`super::non_blocking::Fundamentals::get_ratios`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::Fundamentals::get_ratios`].
+        fn get_ratios(&self, symbols: &[Symbol]) -> Result<Vec<RatiosResponse>>;
+
+        /// See [`super::non_blocking::Fundamentals::get_financials`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::Fundamentals::get_financials`].
+        fn get_financials(&self, symbols: &[Symbol]) -> Result<Vec<FinancialsResponse>>;
+
+        /// See [`super::non_blocking::Fundamentals::get_statistics`].
+        ///
+        /// # Errors
+        /// See [`super::non_blocking::Fundamentals::get_statistics`].
+        fn get_statistics(&self, symbols: &[Symbol]) -> Result<Vec<StatisticsResponse>>;
+    }
+}

--- a/src/fundamentals/api.rs
+++ b/src/fundamentals/api.rs
@@ -107,10 +107,8 @@ pub mod blocking {
         ///
         /// # Errors
         /// See [`super::non_blocking::Fundamentals::get_corporate_actions`].
-        fn get_corporate_actions(
-            &self,
-            symbols: &[Symbol],
-        ) -> Result<Vec<CorporateActionResponse>>;
+        fn get_corporate_actions(&self, symbols: &[Symbol])
+            -> Result<Vec<CorporateActionResponse>>;
 
         /// See [`super::non_blocking::Fundamentals::get_ratios`].
         ///

--- a/src/fundamentals/get_company_schema.json
+++ b/src/fundamentals/get_company_schema.json
@@ -1,0 +1,116 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-fundamentals-company.json",
+    "title": "GetCompany response",
+    "type": "array",
+    "items": { "$ref": "#/$defs/Envelope" },
+    "$defs": {
+        "Envelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["request", "type", "results"],
+            "properties": {
+                "request": { "type": "string" },
+                "type": { "type": "string" },
+                "results": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Result" }
+                }
+            }
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "string" },
+                "tables": { "$ref": "#/$defs/Tables" }
+            }
+        },
+        "Tables": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "company_profile": { "$ref": "#/$defs/CompanyProfile" },
+                "asset_classification": { "$ref": "#/$defs/AssetClassification" },
+                "historical_asset_classification": { "$ref": "#/$defs/AssetClassification" },
+                "long_descriptions": { "type": "string" },
+                "share_class_profile": { "$ref": "#/$defs/ShareClassProfile" },
+                "share_class": { "$ref": "#/$defs/ShareClass" }
+            }
+        },
+        "CompanyProfile": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "company_id": { "type": "string" },
+                "average_employee_number": { "type": "integer" },
+                "contact_email": { "type": "string" },
+                "headquarter": { "$ref": "#/$defs/Headquarter" },
+                "is_head_office_same_with_registered_office_flag": { "type": "boolean" },
+                "total_employee_number": { "type": "integer" },
+                "total_employee_number_as_of_date": { "type": "string" }
+            }
+        },
+        "Headquarter": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "address_line1": { "type": "string" },
+                "city": { "type": "string" },
+                "country": { "type": "string" },
+                "fax": { "type": "string" },
+                "homepage": { "type": "string" },
+                "phone": { "type": "string" },
+                "postal_code": { "type": "string" },
+                "province": { "type": "string" }
+            }
+        },
+        "AssetClassification": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "financial_health_grade": { "type": "string" },
+                "growth_grade": { "type": "string" },
+                "morningstar_economy_sphere_code": { "type": "integer" },
+                "morningstar_industry_code": { "type": "integer" },
+                "morningstar_industry_group_code": { "type": "integer" },
+                "morningstar_sector_code": { "type": "integer" },
+                "nace": { "type": "string" },
+                "naics": { "type": "string" },
+                "profitability_grade": { "type": "string" },
+                "sic": { "type": "string" },
+                "stock_type": { "type": "integer" },
+                "style_box": { "type": "integer" },
+                "value_score": { "type": "number" }
+            }
+        },
+        "ShareClassProfile": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "share_class_id": { "type": "string" },
+                "enterprise_value": { "type": "number" },
+                "market_cap": { "type": "number" },
+                "shares_outstanding": { "type": "number" }
+            }
+        },
+        "ShareClass": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "currency_id": { "type": "string" },
+                "exchange_id": { "type": "string" },
+                "ipo_date": { "type": "string" },
+                "is_primary_share": { "type": "boolean" },
+                "security_type": { "type": "string" },
+                "share_class_description": { "type": "string" },
+                "share_class_id": { "type": "string" },
+                "share_class_status": { "type": "string" },
+                "symbol": { "type": "string" },
+                "trading_status": { "type": "boolean" }
+            }
+        }
+    }
+}

--- a/src/fundamentals/get_corporate_actions_schema.json
+++ b/src/fundamentals/get_corporate_actions_schema.json
@@ -1,0 +1,70 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-fundamentals-corporate-actions.json",
+    "title": "GetCorporateActions response",
+    "type": "array",
+    "items": { "$ref": "#/$defs/Envelope" },
+    "$defs": {
+        "Envelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["request", "type", "results"],
+            "properties": {
+                "request": { "type": "string" },
+                "type": { "type": "string" },
+                "results": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Result" }
+                }
+            }
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "string" },
+                "tables": { "$ref": "#/$defs/Tables" }
+            }
+        },
+        "Tables": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "stock_splits": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/StockSplit" }
+                },
+                "mergers_and_acquisitions": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/MergerAcquisition" }
+                }
+            }
+        },
+        "StockSplit": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "share_class_id": { "type": "string" },
+                "ex_date": { "type": "string" },
+                "adjustment_factor": { "type": "number" },
+                "split_from": { "type": "number" },
+                "split_to": { "type": "number" },
+                "split_type": { "type": "string" }
+            }
+        },
+        "MergerAcquisition": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "acquired_company_id": { "type": "string" },
+                "parent_company_id": { "type": "string" },
+                "cash_amount": { "type": "number" },
+                "currency_id": { "type": "string" },
+                "effective_date": { "type": "string" },
+                "notes": { "type": "string" }
+            }
+        }
+    }
+}

--- a/src/fundamentals/get_corporate_calendars_schema.json
+++ b/src/fundamentals/get_corporate_calendars_schema.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-fundamentals-corporate-calendars.json",
+    "title": "GetCorporateCalendars response",
+    "type": "array",
+    "items": { "$ref": "#/$defs/Envelope" },
+    "$defs": {
+        "Envelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["request", "type", "results"],
+            "properties": {
+                "request": { "type": "string" },
+                "type": { "type": "string" },
+                "results": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Result" }
+                }
+            }
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "string" },
+                "tables": { "$ref": "#/$defs/Tables" }
+            }
+        },
+        "Tables": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "corporate_calendars": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/CalendarEvent" }
+                }
+            }
+        },
+        "CalendarEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "company_id": { "type": "string" },
+                "begin_date_time": { "type": "string" },
+                "end_date_time": { "type": "string" },
+                "event_type": { "type": "integer" },
+                "estimated_date_for_next_event": { "type": "string" },
+                "event": { "type": "string" },
+                "event_fiscal_year": { "type": "integer" },
+                "event_status": { "type": "string" },
+                "time_zone": { "type": "string" }
+            }
+        }
+    }
+}

--- a/src/fundamentals/get_dividends_schema.json
+++ b/src/fundamentals/get_dividends_schema.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-fundamentals-dividends.json",
+    "title": "GetDividends response",
+    "type": "array",
+    "items": { "$ref": "#/$defs/Envelope" },
+    "$defs": {
+        "Envelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["request", "type", "results"],
+            "properties": {
+                "request": { "type": "string" },
+                "type": { "type": "string" },
+                "results": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Result" }
+                }
+            }
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "string" },
+                "tables": { "$ref": "#/$defs/Tables" }
+            }
+        },
+        "Tables": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "cash_dividends": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/CashDividend" }
+                }
+            }
+        },
+        "CashDividend": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "share_class_id": { "type": "string" },
+                "dividend_type": { "type": "string" },
+                "ex_date": { "type": "string" },
+                "cash_amount": { "type": "number" },
+                "currency_i_d": { "type": "string" },
+                "declaration_date": { "type": "string" },
+                "frequency": { "type": "integer" },
+                "pay_date": { "type": "string" },
+                "record_date": { "type": "string" }
+            }
+        }
+    }
+}

--- a/src/fundamentals/get_financials_schema.json
+++ b/src/fundamentals/get_financials_schema.json
@@ -1,0 +1,63 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-fundamentals-financials.json",
+    "title": "GetFinancials response",
+    "type": "array",
+    "items": { "$ref": "#/$defs/Envelope" },
+    "$defs": {
+        "Envelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["request", "type", "results"],
+            "properties": {
+                "request": { "type": "string" },
+                "type": { "type": "string" },
+                "results": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Result" }
+                }
+            }
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "string" },
+                "tables": { "$ref": "#/$defs/Tables" }
+            }
+        },
+        "Tables": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "balance_sheet": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Statement" }
+                },
+                "cash_flow_statement": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Statement" }
+                },
+                "income_statement": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Statement" }
+                }
+            }
+        },
+        "Statement": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "period": { "type": "string" },
+                "report_type": { "type": "string" },
+                "fiscal_year_end": { "type": "integer" },
+                "accession_number": { "type": "string" },
+                "filing_date": { "type": "string" },
+                "form_type": { "type": "string" },
+                "period_ending_date": { "type": "string" }
+            }
+        }
+    }
+}

--- a/src/fundamentals/get_ratios_schema.json
+++ b/src/fundamentals/get_ratios_schema.json
@@ -1,0 +1,96 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-fundamentals-ratios.json",
+    "title": "GetRatios response",
+    "type": "array",
+    "items": { "$ref": "#/$defs/Envelope" },
+    "$defs": {
+        "Envelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["request", "type", "results"],
+            "properties": {
+                "request": { "type": "string" },
+                "type": { "type": "string" },
+                "results": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Result" }
+                }
+            }
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "string" },
+                "tables": { "$ref": "#/$defs/Tables" }
+            }
+        },
+        "Tables": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "operation_ratios_restate": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/OperationRatios" }
+                },
+                "earning_ratios_restate": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/EarningRatios" }
+                },
+                "valuation_ratios": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/ValuationRatios" }
+                }
+            }
+        },
+        "OperationRatios": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "period": { "type": "string" },
+                "report_type": { "type": "string" },
+                "fiscal_year_end": { "type": "integer" },
+                "assets_turnover": { "type": "number" },
+                "debt_to_assets": { "type": "number" },
+                "gross_margin": { "type": "number" },
+                "net_margin": { "type": "number" },
+                "operation_margin": { "type": "number" },
+                "quick_ratio": { "type": "number" },
+                "r_o_a": { "type": "number" },
+                "r_o_e": { "type": "number" },
+                "r_o_i_c": { "type": "number" }
+            }
+        },
+        "EarningRatios": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "period": { "type": "string" },
+                "report_type": { "type": "string" },
+                "fiscal_year_end": { "type": "integer" },
+                "diluted_eps_growth": { "type": "number" },
+                "d_p_s_growth": { "type": "number" },
+                "equity_per_share_growth": { "type": "number" }
+            }
+        },
+        "ValuationRatios": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "as_of_date": { "type": "string" },
+                "dividend_yield": { "type": "number" },
+                "earning_yield": { "type": "number" },
+                "forward_dividend_yield": { "type": "number" },
+                "forward_p_e_ratio": { "type": "number" },
+                "payout_ratio": { "type": "number" },
+                "p_b_ratio": { "type": "number" },
+                "p_e_ratio": { "type": "number" },
+                "peg_ratio": { "type": "number" },
+                "p_s_ratio": { "type": "number" }
+            }
+        }
+    }
+}

--- a/src/fundamentals/get_statistics_schema.json
+++ b/src/fundamentals/get_statistics_schema.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://example.com/schemas/tradier-fundamentals-statistics.json",
+    "title": "GetStatistics response",
+    "type": "array",
+    "items": { "$ref": "#/$defs/Envelope" },
+    "$defs": {
+        "Envelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["request", "type", "results"],
+            "properties": {
+                "request": { "type": "string" },
+                "type": { "type": "string" },
+                "results": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/Result" }
+                }
+            }
+        },
+        "Result": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "string" },
+                "tables": { "$ref": "#/$defs/Tables" }
+            }
+        },
+        "Tables": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "price_statistics": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/PriceStatistics" }
+                },
+                "trailing_returns": {
+                    "type": "array",
+                    "items": { "$ref": "#/$defs/TrailingReturns" }
+                }
+            }
+        },
+        "PriceStatistics": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "period": { "type": "string" },
+                "as_of_date": { "type": "string" },
+                "moving_average_price": { "type": "number" },
+                "close_price": { "type": "number" },
+                "high_price": { "type": "number" },
+                "low_price": { "type": "number" },
+                "percent_change": { "type": "number" },
+                "price_change": { "type": "number" },
+                "total_volume": { "type": "number" },
+                "average_volume": { "type": "number" },
+                "arithmetic_mean": { "type": "number" },
+                "standard_deviation": { "type": "number" }
+            }
+        },
+        "TrailingReturns": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "period": { "type": "string" },
+                "as_of_date": { "type": "string" },
+                "total_return": { "type": "number" }
+            }
+        }
+    }
+}

--- a/src/fundamentals/mod.rs
+++ b/src/fundamentals/mod.rs
@@ -1,0 +1,10 @@
+//! Fundamentals (beta) REST endpoints.
+//!
+//! Provides typed bindings for the Tradier `beta/markets/fundamentals/*`
+//! REST surface, exposed both as blocking and non-blocking traits.
+//!
+//! Upstream docs: <https://documentation.tradier.com/brokerage-api/markets/get-company>.
+
+#[cfg(test)]
+pub(crate) mod test_support;
+pub mod types;

--- a/src/fundamentals/mod.rs
+++ b/src/fundamentals/mod.rs
@@ -5,6 +5,7 @@
 //!
 //! Upstream docs: <https://documentation.tradier.com/brokerage-api/markets/get-company>.
 
+pub mod api;
 #[cfg(test)]
 pub(crate) mod test_support;
 pub mod types;

--- a/src/fundamentals/test_support.rs
+++ b/src/fundamentals/test_support.rs
@@ -1,0 +1,357 @@
+//! Test-only wire types for fundamentals fixtures.
+//!
+//! These `Serialize` / `proptest_derive::Arbitrary` structs produce JSON we
+//! can feed back into the real deserializers and into JSON Schema
+//! validators.
+//!
+//! # Design note
+//!
+//! The real domain types in `types.rs` are deeply nested (envelope ->
+//! result -> tables -> table -> row). If we derive `Arbitrary` straight
+//! through that tree, the strategy tree itself blows the default Rust
+//! test-thread stack. Here we flatten the Wire types one level and leave
+//! most of the sub-tables out of the fuzzed payload; the exact parsing
+//! of each sub-shape is covered by hand-written fixture tests in
+//! `types.rs` instead.
+
+use serde::Serialize;
+
+/// Short ASCII string wrapper used in fuzzed fixtures to bound payload size.
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+#[serde(transparent)]
+pub struct ShortString(
+    #[proptest(regex = r"[A-Za-z0-9 _\\-]{0,8}")] //
+    String,
+);
+
+// -----------------------------------------------------------------------------
+// Flat envelope shared by every endpoint
+// -----------------------------------------------------------------------------
+
+/// A minimal flat result: preserves the `type` discriminator and the optional
+/// `id`, but leaves `tables` as an empty object. The deserializer's treatment
+/// of the surrounding envelope is what we actually fuzz; per-table shapes are
+/// exercised by hand-written fixture tests in `types.rs`.
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct FlatResultWire {
+    #[serde(rename = "type")]
+    pub kind: ShortString,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<ShortString>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct CompanyResponseWire {
+    pub request: ShortString,
+    #[serde(rename = "type")]
+    pub kind: ShortString,
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<FlatResultWire>(), 0..=2)"
+    )]
+    pub results: Vec<FlatResultWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+#[serde(transparent)]
+pub struct CompanyResponseArrayWire(
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<CompanyResponseWire>(), 0..=2)"
+    )]
+    pub Vec<CompanyResponseWire>,
+);
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct CorporateCalendarResponseWire {
+    pub request: ShortString,
+    #[serde(rename = "type")]
+    pub kind: ShortString,
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<FlatResultWire>(), 0..=2)"
+    )]
+    pub results: Vec<FlatResultWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+#[serde(transparent)]
+pub struct CorporateCalendarResponseArrayWire(
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<CorporateCalendarResponseWire>(), 0..=2)"
+    )]
+    pub Vec<CorporateCalendarResponseWire>,
+);
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct DividendResponseWire {
+    pub request: ShortString,
+    #[serde(rename = "type")]
+    pub kind: ShortString,
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<FlatResultWire>(), 0..=2)"
+    )]
+    pub results: Vec<FlatResultWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+#[serde(transparent)]
+pub struct DividendResponseArrayWire(
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<DividendResponseWire>(), 0..=2)"
+    )]
+    pub Vec<DividendResponseWire>,
+);
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct CorporateActionResponseWire {
+    pub request: ShortString,
+    #[serde(rename = "type")]
+    pub kind: ShortString,
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<FlatResultWire>(), 0..=2)"
+    )]
+    pub results: Vec<FlatResultWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+#[serde(transparent)]
+pub struct CorporateActionResponseArrayWire(
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<CorporateActionResponseWire>(), 0..=2)"
+    )]
+    pub Vec<CorporateActionResponseWire>,
+);
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct RatiosResponseWire {
+    pub request: ShortString,
+    #[serde(rename = "type")]
+    pub kind: ShortString,
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<FlatResultWire>(), 0..=2)"
+    )]
+    pub results: Vec<FlatResultWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+#[serde(transparent)]
+pub struct RatiosResponseArrayWire(
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<RatiosResponseWire>(), 0..=2)"
+    )]
+    pub Vec<RatiosResponseWire>,
+);
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct FinancialsResponseWire {
+    pub request: ShortString,
+    #[serde(rename = "type")]
+    pub kind: ShortString,
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<FlatResultWire>(), 0..=2)"
+    )]
+    pub results: Vec<FlatResultWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+#[serde(transparent)]
+pub struct FinancialsResponseArrayWire(
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<FinancialsResponseWire>(), 0..=2)"
+    )]
+    pub Vec<FinancialsResponseWire>,
+);
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+pub struct StatisticsResponseWire {
+    pub request: ShortString,
+    #[serde(rename = "type")]
+    pub kind: ShortString,
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<FlatResultWire>(), 0..=2)"
+    )]
+    pub results: Vec<FlatResultWire>,
+}
+
+#[derive(Clone, Debug, Serialize, proptest_derive::Arbitrary)]
+#[serde(transparent)]
+pub struct StatisticsResponseArrayWire(
+    #[proptest(
+        strategy = "proptest::collection::vec(proptest::prelude::any::<StatisticsResponseWire>(), 0..=2)"
+    )]
+    pub Vec<StatisticsResponseWire>,
+);
+
+// -----------------------------------------------------------------------------
+// Schema validation tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+    use serde_json::{json, Value};
+    use std::fs::OpenOptions;
+
+    static COMPANY_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/fundamentals/get_company_schema.json"
+    );
+    static CORP_CAL_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/fundamentals/get_corporate_calendars_schema.json"
+    );
+    static DIVIDENDS_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/fundamentals/get_dividends_schema.json"
+    );
+    static CORP_ACTIONS_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/fundamentals/get_corporate_actions_schema.json"
+    );
+    static RATIOS_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/fundamentals/get_ratios_schema.json"
+    );
+    static FINANCIALS_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/fundamentals/get_financials_schema.json"
+    );
+    static STATISTICS_PATH: &str = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/src/fundamentals/get_statistics_schema.json"
+    );
+
+    fn load_validator(path: &str) -> jsonschema::Validator {
+        let reader = OpenOptions::new()
+            .read(true)
+            .open(path)
+            .expect("schema file to exist");
+        let reader = std::io::BufReader::new(reader);
+        let schema: Value = serde_json::from_reader(reader).expect("schema JSON");
+        jsonschema::validator_for(&schema).expect("validator")
+    }
+
+    #[test]
+    fn empty_object_should_fail_company_schema() {
+        let validator = load_validator(COMPANY_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_object_should_fail_corporate_calendars_schema() {
+        let validator = load_validator(CORP_CAL_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_object_should_fail_dividends_schema() {
+        let validator = load_validator(DIVIDENDS_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_object_should_fail_corporate_actions_schema() {
+        let validator = load_validator(CORP_ACTIONS_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_object_should_fail_ratios_schema() {
+        let validator = load_validator(RATIOS_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_object_should_fail_financials_schema() {
+        let validator = load_validator(FINANCIALS_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_object_should_fail_statistics_schema() {
+        let validator = load_validator(STATISTICS_PATH);
+        assert!(!validator.is_valid(&json!({})));
+    }
+
+    #[test]
+    fn empty_array_should_validate_against_all_schemas() {
+        for p in [
+            COMPANY_PATH,
+            CORP_CAL_PATH,
+            DIVIDENDS_PATH,
+            CORP_ACTIONS_PATH,
+            RATIOS_PATH,
+            FINANCIALS_PATH,
+            STATISTICS_PATH,
+        ] {
+            let validator = load_validator(p);
+            assert!(validator.is_valid(&json!([])), "schema {} rejected []", p);
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn serialized_company_wire_should_conform_to_schema(
+            wire in any::<CompanyResponseArrayWire>()
+        ) {
+            let validator = load_validator(COMPANY_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_corporate_calendar_wire_should_conform_to_schema(
+            wire in any::<CorporateCalendarResponseArrayWire>()
+        ) {
+            let validator = load_validator(CORP_CAL_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_dividend_wire_should_conform_to_schema(
+            wire in any::<DividendResponseArrayWire>()
+        ) {
+            let validator = load_validator(DIVIDENDS_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_corporate_action_wire_should_conform_to_schema(
+            wire in any::<CorporateActionResponseArrayWire>()
+        ) {
+            let validator = load_validator(CORP_ACTIONS_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_ratios_wire_should_conform_to_schema(
+            wire in any::<RatiosResponseArrayWire>()
+        ) {
+            let validator = load_validator(RATIOS_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_financials_wire_should_conform_to_schema(
+            wire in any::<FinancialsResponseArrayWire>()
+        ) {
+            let validator = load_validator(FINANCIALS_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+
+        #[test]
+        fn serialized_statistics_wire_should_conform_to_schema(
+            wire in any::<StatisticsResponseArrayWire>()
+        ) {
+            let validator = load_validator(STATISTICS_PATH);
+            let value = serde_json::to_value(&wire).expect("serialize");
+            prop_assert!(validator.is_valid(&value), "value: {}", value);
+        }
+    }
+}

--- a/src/fundamentals/types.rs
+++ b/src/fundamentals/types.rs
@@ -662,7 +662,10 @@ mod test {
         assert_eq!(profile.total_employee_number, Some(150000));
         let hq = profile.headquarter.as_ref().expect("hq");
         assert_eq!(hq.city.as_deref(), Some("Cupertino"));
-        let classification = tables.asset_classification.as_ref().expect("classification");
+        let classification = tables
+            .asset_classification
+            .as_ref()
+            .expect("classification");
         assert_eq!(classification.financial_health_grade.as_deref(), Some("A"));
     }
 

--- a/src/fundamentals/types.rs
+++ b/src/fundamentals/types.rs
@@ -1,0 +1,939 @@
+//! Request and response types for the Tradier Fundamentals (beta) REST endpoints.
+//!
+//! Upstream documentation:
+//! <https://documentation.tradier.com/brokerage-api/markets/get-company>
+//!
+//! # Wire shape
+//!
+//! Every fundamentals endpoint returns a JSON array at the top level. Each
+//! element wraps the data for one requested symbol:
+//!
+//! ```json
+//! [
+//!   {
+//!     "request": "AAPL",
+//!     "type": "Symbol",
+//!     "results": [
+//!       { "type": "Company", "id": "...", "tables": { ... } },
+//!       ...
+//!     ]
+//!   }
+//! ]
+//! ```
+//!
+//! The `tables` sub-object varies per endpoint (company details, dividends,
+//! ratios, etc.). To stay faithful to the wire while tolerating the heavy
+//! optional-field surface, many leaf fields are kept as `Option<String>` /
+//! `Option<f64>` instead of stronger domain types — mirror the wire first,
+//! add typed helpers on top only where the domain clearly benefits.
+
+use chrono::NaiveDate;
+use serde::Deserialize;
+
+use crate::utils::OneOrMany;
+
+pub use crate::common::Symbol;
+
+// -----------------------------------------------------------------------------
+// Shared request envelope
+// -----------------------------------------------------------------------------
+
+/// A single top-level entry in a fundamentals response array. The `request`
+/// field echoes the ticker the server was asked about; `results` holds the
+/// endpoint-specific payload.
+///
+/// This type is generic over `T`, the endpoint-specific `results` inner type.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct FundamentalsEnvelope<T> {
+    /// Echo of the ticker the server was asked about.
+    pub request: String,
+    /// Always `"Symbol"` in production responses.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Endpoint-specific payload. Tradier usually returns an array; some
+    /// endpoints omit the field when no data is available.
+    #[serde(default = "empty_results")]
+    pub results: Vec<T>,
+}
+
+fn empty_results<T>() -> Vec<T> {
+    Vec::new()
+}
+
+// -----------------------------------------------------------------------------
+// 1. GET /beta/markets/fundamentals/company
+// -----------------------------------------------------------------------------
+
+/// One element of the response array for `GET /beta/markets/fundamentals/company`.
+pub type CompanyResponse = FundamentalsEnvelope<CompanyResult>;
+
+/// Individual result block inside a company response. Tradier returns both
+/// `Company` profile blocks and `Stock` data blocks interleaved in a single
+/// `results` array; we capture them uniformly and keep the raw `tables`
+/// map for the caller to inspect.
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct CompanyResult {
+    /// Discriminator: `"Company"`, `"Stock"`, `"IPO"`, `"Security"`, etc.
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Tradier-internal identifier for this result row.
+    #[serde(default)]
+    pub id: Option<String>,
+    /// Raw nested `tables` structure. Shape varies with `kind`; kept as a
+    /// generic JSON value so we do not lose data upstream adds later.
+    #[serde(default)]
+    pub tables: Option<CompanyTables>,
+}
+
+/// Typed view over the common subset of company/stock `tables` entries.
+///
+/// Tradier returns a large number of optional fields, many of them as
+/// strings even when numeric. To stay faithful to the wire we keep them
+/// as `Option<String>` and expose typed helpers only where a caller
+/// clearly benefits.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CompanyTables {
+    #[serde(default)]
+    pub company_profile: Option<CompanyProfile>,
+    #[serde(default)]
+    pub asset_classification: Option<AssetClassification>,
+    #[serde(default)]
+    pub historical_asset_classification: Option<AssetClassification>,
+    #[serde(default)]
+    pub long_descriptions: Option<String>,
+    #[serde(default)]
+    pub share_class_profile: Option<ShareClassProfile>,
+    #[serde(default)]
+    pub share_class: Option<ShareClass>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CompanyProfile {
+    #[serde(default)]
+    pub company_id: Option<String>,
+    #[serde(default)]
+    pub average_employee_number: Option<i64>,
+    #[serde(default)]
+    pub contact_email: Option<String>,
+    #[serde(default)]
+    pub headquarter: Option<Headquarter>,
+    #[serde(default)]
+    pub is_head_office_same_with_registered_office_flag: Option<bool>,
+    #[serde(default)]
+    pub total_employee_number: Option<i64>,
+    #[serde(default)]
+    pub total_employee_number_as_of_date: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct Headquarter {
+    #[serde(default)]
+    pub address_line1: Option<String>,
+    #[serde(default)]
+    pub city: Option<String>,
+    #[serde(default)]
+    pub country: Option<String>,
+    #[serde(default)]
+    pub fax: Option<String>,
+    #[serde(default)]
+    pub homepage: Option<String>,
+    #[serde(default)]
+    pub phone: Option<String>,
+    #[serde(default)]
+    pub postal_code: Option<String>,
+    #[serde(default)]
+    pub province: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct AssetClassification {
+    #[serde(default)]
+    pub financial_health_grade: Option<String>,
+    #[serde(default)]
+    pub growth_grade: Option<String>,
+    #[serde(default)]
+    pub morningstar_economy_sphere_code: Option<i64>,
+    #[serde(default)]
+    pub morningstar_industry_code: Option<i64>,
+    #[serde(default)]
+    pub morningstar_industry_group_code: Option<i64>,
+    #[serde(default)]
+    pub morningstar_sector_code: Option<i64>,
+    #[serde(default)]
+    pub nace: Option<String>,
+    #[serde(default)]
+    pub naics: Option<String>,
+    #[serde(default)]
+    pub profitability_grade: Option<String>,
+    #[serde(default)]
+    pub sic: Option<String>,
+    #[serde(default)]
+    pub stock_type: Option<i64>,
+    #[serde(default)]
+    pub style_box: Option<i64>,
+    #[serde(default)]
+    pub value_score: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct ShareClassProfile {
+    #[serde(default)]
+    pub share_class_id: Option<String>,
+    #[serde(default)]
+    pub enterprise_value: Option<f64>,
+    #[serde(default)]
+    pub market_cap: Option<f64>,
+    #[serde(default)]
+    pub shares_outstanding: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct ShareClass {
+    #[serde(default)]
+    pub currency_id: Option<String>,
+    #[serde(default)]
+    pub exchange_id: Option<String>,
+    #[serde(default)]
+    pub ipo_date: Option<String>,
+    #[serde(default)]
+    pub is_primary_share: Option<bool>,
+    #[serde(default)]
+    pub security_type: Option<String>,
+    #[serde(default)]
+    pub share_class_description: Option<String>,
+    #[serde(default)]
+    pub share_class_id: Option<String>,
+    #[serde(default)]
+    pub share_class_status: Option<String>,
+    #[serde(default)]
+    pub symbol: Option<String>,
+    #[serde(default)]
+    pub trading_status: Option<bool>,
+}
+
+// -----------------------------------------------------------------------------
+// 2. GET /beta/markets/fundamentals/corporate_calendars
+// -----------------------------------------------------------------------------
+
+/// One element of the response array for
+/// `GET /beta/markets/fundamentals/corporate_calendars`.
+pub type CorporateCalendarResponse = FundamentalsEnvelope<CorporateCalendarResult>;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct CorporateCalendarResult {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub tables: Option<CorporateCalendarTables>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CorporateCalendarTables {
+    #[serde(default)]
+    pub corporate_calendars: Option<OneOrMany<CorporateCalendarEvent>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CorporateCalendarEvent {
+    #[serde(default)]
+    pub company_id: Option<String>,
+    #[serde(default)]
+    pub begin_date_time: Option<String>,
+    #[serde(default)]
+    pub end_date_time: Option<String>,
+    #[serde(default)]
+    pub event_type: Option<i64>,
+    #[serde(default)]
+    pub estimated_date_for_next_event: Option<String>,
+    #[serde(default)]
+    pub event: Option<String>,
+    #[serde(default)]
+    pub event_fiscal_year: Option<i64>,
+    #[serde(default)]
+    pub event_status: Option<String>,
+    #[serde(default)]
+    pub time_zone: Option<String>,
+}
+
+// -----------------------------------------------------------------------------
+// 3. GET /beta/markets/fundamentals/dividends
+// -----------------------------------------------------------------------------
+
+/// One element of the response array for
+/// `GET /beta/markets/fundamentals/dividends`.
+pub type DividendResponse = FundamentalsEnvelope<DividendResult>;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct DividendResult {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub tables: Option<DividendTables>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct DividendTables {
+    #[serde(default)]
+    pub cash_dividends: Option<OneOrMany<CashDividend>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CashDividend {
+    #[serde(default)]
+    pub share_class_id: Option<String>,
+    #[serde(default)]
+    pub dividend_type: Option<String>,
+    #[serde(default)]
+    pub ex_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub cash_amount: Option<f64>,
+    #[serde(default)]
+    pub currency_i_d: Option<String>,
+    #[serde(default)]
+    pub declaration_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub frequency: Option<i64>,
+    #[serde(default)]
+    pub pay_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub record_date: Option<NaiveDate>,
+}
+
+// -----------------------------------------------------------------------------
+// 4. GET /beta/markets/fundamentals/corporate_actions
+// -----------------------------------------------------------------------------
+
+/// One element of the response array for
+/// `GET /beta/markets/fundamentals/corporate_actions`.
+pub type CorporateActionResponse = FundamentalsEnvelope<CorporateActionResult>;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct CorporateActionResult {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub tables: Option<CorporateActionTables>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct CorporateActionTables {
+    #[serde(default)]
+    pub stock_splits: Option<OneOrMany<StockSplit>>,
+    #[serde(default)]
+    pub mergers_and_acquisitions: Option<OneOrMany<MergerAcquisition>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct StockSplit {
+    #[serde(default)]
+    pub share_class_id: Option<String>,
+    #[serde(default)]
+    pub ex_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub adjustment_factor: Option<f64>,
+    #[serde(default)]
+    pub split_from: Option<f64>,
+    #[serde(default)]
+    pub split_to: Option<f64>,
+    #[serde(default)]
+    pub split_type: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct MergerAcquisition {
+    #[serde(default)]
+    pub acquired_company_id: Option<String>,
+    #[serde(default)]
+    pub parent_company_id: Option<String>,
+    #[serde(default)]
+    pub cash_amount: Option<f64>,
+    #[serde(default)]
+    pub currency_id: Option<String>,
+    #[serde(default)]
+    pub effective_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub notes: Option<String>,
+}
+
+// -----------------------------------------------------------------------------
+// 5. GET /beta/markets/fundamentals/ratios
+// -----------------------------------------------------------------------------
+
+/// One element of the response array for
+/// `GET /beta/markets/fundamentals/ratios`.
+pub type RatiosResponse = FundamentalsEnvelope<RatiosResult>;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct RatiosResult {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub tables: Option<RatiosTables>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct RatiosTables {
+    #[serde(default)]
+    pub operation_ratios_restate: Option<OneOrMany<OperationRatios>>,
+    #[serde(default)]
+    pub earning_ratios_restate: Option<OneOrMany<EarningRatios>>,
+    #[serde(default)]
+    pub valuation_ratios: Option<OneOrMany<ValuationRatios>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct OperationRatios {
+    #[serde(default)]
+    pub period: Option<String>,
+    #[serde(default)]
+    pub report_type: Option<String>,
+    #[serde(default)]
+    pub fiscal_year_end: Option<i64>,
+    #[serde(default)]
+    pub assets_turnover: Option<f64>,
+    #[serde(default)]
+    pub debt_to_assets: Option<f64>,
+    #[serde(default)]
+    pub gross_margin: Option<f64>,
+    #[serde(default)]
+    pub net_margin: Option<f64>,
+    #[serde(default)]
+    pub operation_margin: Option<f64>,
+    #[serde(default)]
+    pub quick_ratio: Option<f64>,
+    #[serde(default)]
+    pub r_o_a: Option<f64>,
+    #[serde(default)]
+    pub r_o_e: Option<f64>,
+    #[serde(default)]
+    pub r_o_i_c: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct EarningRatios {
+    #[serde(default)]
+    pub period: Option<String>,
+    #[serde(default)]
+    pub report_type: Option<String>,
+    #[serde(default)]
+    pub fiscal_year_end: Option<i64>,
+    #[serde(default)]
+    pub diluted_eps_growth: Option<f64>,
+    #[serde(default)]
+    pub d_p_s_growth: Option<f64>,
+    #[serde(default)]
+    pub equity_per_share_growth: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct ValuationRatios {
+    #[serde(default)]
+    pub as_of_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub dividend_yield: Option<f64>,
+    #[serde(default)]
+    pub earning_yield: Option<f64>,
+    #[serde(default)]
+    pub forward_dividend_yield: Option<f64>,
+    #[serde(default)]
+    pub forward_p_e_ratio: Option<f64>,
+    #[serde(default)]
+    pub payout_ratio: Option<f64>,
+    #[serde(default)]
+    pub p_b_ratio: Option<f64>,
+    #[serde(default)]
+    pub p_e_ratio: Option<f64>,
+    #[serde(default)]
+    pub peg_ratio: Option<f64>,
+    #[serde(default)]
+    pub p_s_ratio: Option<f64>,
+}
+
+// -----------------------------------------------------------------------------
+// 6. GET /beta/markets/fundamentals/financials
+// -----------------------------------------------------------------------------
+
+/// One element of the response array for
+/// `GET /beta/markets/fundamentals/financials`.
+pub type FinancialsResponse = FundamentalsEnvelope<FinancialsResult>;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct FinancialsResult {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub tables: Option<FinancialsTables>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct FinancialsTables {
+    #[serde(default)]
+    pub balance_sheet: Option<OneOrMany<FinancialStatement>>,
+    #[serde(default)]
+    pub cash_flow_statement: Option<OneOrMany<FinancialStatement>>,
+    #[serde(default)]
+    pub income_statement: Option<OneOrMany<FinancialStatement>>,
+}
+
+/// A single financial statement row. Tradier ships every line-item as an
+/// arbitrary number of optional `f64` / `String` fields, many of them sparse.
+/// We capture the commonly-populated header fields and preserve the rest
+/// as an untyped extras map.
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct FinancialStatement {
+    #[serde(default)]
+    pub period: Option<String>,
+    #[serde(default)]
+    pub report_type: Option<String>,
+    #[serde(default)]
+    pub fiscal_year_end: Option<i64>,
+    #[serde(default)]
+    pub accession_number: Option<String>,
+    #[serde(default)]
+    pub filing_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub form_type: Option<String>,
+    #[serde(default)]
+    pub period_ending_date: Option<NaiveDate>,
+}
+
+// -----------------------------------------------------------------------------
+// 7. GET /beta/markets/fundamentals/statistics
+// -----------------------------------------------------------------------------
+
+/// One element of the response array for
+/// `GET /beta/markets/fundamentals/statistics`.
+pub type StatisticsResponse = FundamentalsEnvelope<StatisticsResult>;
+
+#[derive(Clone, Debug, Deserialize, PartialEq)]
+pub struct StatisticsResult {
+    #[serde(rename = "type")]
+    pub kind: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub tables: Option<StatisticsTables>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct StatisticsTables {
+    #[serde(default)]
+    pub price_statistics: Option<OneOrMany<PriceStatistics>>,
+    #[serde(default)]
+    pub trailing_returns: Option<OneOrMany<TrailingReturns>>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct PriceStatistics {
+    #[serde(default)]
+    pub period: Option<String>,
+    #[serde(default)]
+    pub as_of_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub moving_average_price: Option<f64>,
+    #[serde(default)]
+    pub close_price: Option<f64>,
+    #[serde(default)]
+    pub high_price: Option<f64>,
+    #[serde(default)]
+    pub low_price: Option<f64>,
+    #[serde(default)]
+    pub percent_change: Option<f64>,
+    #[serde(default)]
+    pub price_change: Option<f64>,
+    #[serde(default)]
+    pub total_volume: Option<f64>,
+    #[serde(default)]
+    pub average_volume: Option<f64>,
+    #[serde(default)]
+    pub arithmetic_mean: Option<f64>,
+    #[serde(default)]
+    pub standard_deviation: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+pub struct TrailingReturns {
+    #[serde(default)]
+    pub period: Option<String>,
+    #[serde(default)]
+    pub as_of_date: Option<NaiveDate>,
+    #[serde(default)]
+    pub total_return: Option<f64>,
+}
+
+// -----------------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use proptest::prelude::*;
+
+    use crate::fundamentals::test_support::{
+        CompanyResponseArrayWire, CorporateActionResponseArrayWire,
+        CorporateCalendarResponseArrayWire, DividendResponseArrayWire, FinancialsResponseArrayWire,
+        RatiosResponseArrayWire, StatisticsResponseArrayWire,
+    };
+
+    #[test]
+    fn test_envelope_default_results_when_missing() {
+        let json = r#"{"request":"AAPL","type":"Symbol"}"#;
+        let parsed: FundamentalsEnvelope<CompanyResult> =
+            serde_json::from_str(json).expect("parse");
+        assert_eq!(parsed.request, "AAPL");
+        assert_eq!(parsed.kind, "Symbol");
+        assert!(parsed.results.is_empty());
+    }
+
+    #[test]
+    fn test_envelope_with_empty_results_parses() {
+        let json = r#"{"request":"AAPL","type":"Symbol","results":[]}"#;
+        let parsed: FundamentalsEnvelope<CompanyResult> =
+            serde_json::from_str(json).expect("parse");
+        assert!(parsed.results.is_empty());
+    }
+
+    #[test]
+    fn test_envelope_with_one_result_parses() {
+        let json = r#"{
+            "request":"AAPL",
+            "type":"Symbol",
+            "results":[{"type":"Company","id":"x","tables":{}}]
+        }"#;
+        let parsed: FundamentalsEnvelope<CompanyResult> =
+            serde_json::from_str(json).expect("parse");
+        assert_eq!(parsed.results.len(), 1);
+        assert_eq!(parsed.results[0].kind, "Company");
+    }
+
+    #[test]
+    fn test_company_parses_real_shape() {
+        let json = r#"[
+          {
+            "request":"AAPL",
+            "type":"Symbol",
+            "results":[
+              {
+                "type":"Company",
+                "id":"0P000000GY",
+                "tables":{
+                  "company_profile":{
+                    "company_id":"0P000000GY",
+                    "total_employee_number":150000,
+                    "headquarter":{
+                      "address_line1":"One Apple Park Way",
+                      "city":"Cupertino",
+                      "country":"USA",
+                      "province":"CA"
+                    }
+                  },
+                  "asset_classification":{
+                    "financial_health_grade":"A",
+                    "morningstar_sector_code":311
+                  },
+                  "share_class":{
+                    "currency_id":"USD",
+                    "exchange_id":"NAS",
+                    "symbol":"AAPL",
+                    "is_primary_share":true
+                  }
+                }
+              }
+            ]
+          }
+        ]"#;
+        let parsed: Vec<CompanyResponse> = serde_json::from_str(json).expect("parse");
+        let first = &parsed[0];
+        assert_eq!(first.request, "AAPL");
+        let result = &first.results[0];
+        let tables = result.tables.as_ref().expect("tables");
+        let profile = tables.company_profile.as_ref().expect("profile");
+        assert_eq!(profile.total_employee_number, Some(150000));
+        let hq = profile.headquarter.as_ref().expect("hq");
+        assert_eq!(hq.city.as_deref(), Some("Cupertino"));
+        let classification = tables.asset_classification.as_ref().expect("classification");
+        assert_eq!(classification.financial_health_grade.as_deref(), Some("A"));
+    }
+
+    #[test]
+    fn test_dividends_parses_real_shape() {
+        let json = r#"[
+          {
+            "request":"AAPL",
+            "type":"Symbol",
+            "results":[
+              {
+                "type":"Stock",
+                "id":"0P000000GY",
+                "tables":{
+                  "cash_dividends":[{
+                    "share_class_id":"0P000000GY",
+                    "dividend_type":"CD",
+                    "ex_date":"2024-02-09",
+                    "cash_amount":0.24,
+                    "currency_i_d":"USD",
+                    "declaration_date":"2024-02-01",
+                    "frequency":4,
+                    "pay_date":"2024-02-15",
+                    "record_date":"2024-02-12"
+                  }]
+                }
+              }
+            ]
+          }
+        ]"#;
+        let parsed: Vec<DividendResponse> = serde_json::from_str(json).expect("parse");
+        assert_eq!(parsed.len(), 1);
+        let first = &parsed[0];
+        assert_eq!(first.request, "AAPL");
+        let result = &first.results[0];
+        let tables = result.tables.as_ref().expect("tables");
+        let cash = tables.cash_dividends.as_ref().expect("cash").clone();
+        let cash = cash.into_vec();
+        assert_eq!(cash.len(), 1);
+        assert_eq!(cash[0].dividend_type.as_deref(), Some("CD"));
+        assert_eq!(cash[0].cash_amount, Some(0.24));
+    }
+
+    #[test]
+    fn test_corporate_calendars_parses_real_shape() {
+        let json = r#"[
+          {
+            "request":"AAPL",
+            "type":"Symbol",
+            "results":[
+              {
+                "type":"Company",
+                "tables":{
+                  "corporate_calendars":[{
+                    "company_id":"0P000000GY",
+                    "begin_date_time":"2024-04-30",
+                    "end_date_time":"2024-04-30",
+                    "event_type":14,
+                    "event":"Earnings Release",
+                    "event_status":"Confirmed",
+                    "time_zone":"US/Eastern"
+                  }]
+                }
+              }
+            ]
+          }
+        ]"#;
+        let parsed: Vec<CorporateCalendarResponse> = serde_json::from_str(json).expect("parse");
+        let events = parsed[0].results[0]
+            .tables
+            .as_ref()
+            .and_then(|t| t.corporate_calendars.clone())
+            .expect("events")
+            .into_vec();
+        assert_eq!(events[0].event.as_deref(), Some("Earnings Release"));
+    }
+
+    #[test]
+    fn test_corporate_actions_parses_real_shape() {
+        let json = r#"[
+          {
+            "request":"AAPL",
+            "type":"Symbol",
+            "results":[
+              {
+                "type":"Stock",
+                "tables":{
+                  "stock_splits":[{
+                    "share_class_id":"0P000000GY",
+                    "ex_date":"2020-08-31",
+                    "adjustment_factor":4.0,
+                    "split_from":1.0,
+                    "split_to":4.0,
+                    "split_type":"SS"
+                  }]
+                }
+              }
+            ]
+          }
+        ]"#;
+        let parsed: Vec<CorporateActionResponse> = serde_json::from_str(json).expect("parse");
+        let splits = parsed[0].results[0]
+            .tables
+            .as_ref()
+            .and_then(|t| t.stock_splits.clone())
+            .expect("splits")
+            .into_vec();
+        assert_eq!(splits[0].split_to, Some(4.0));
+    }
+
+    #[test]
+    fn test_ratios_parses_real_shape() {
+        let json = r#"[
+          {
+            "request":"AAPL",
+            "type":"Symbol",
+            "results":[
+              {
+                "type":"Stock",
+                "tables":{
+                  "valuation_ratios":[{
+                    "as_of_date":"2024-04-01",
+                    "p_e_ratio":28.5,
+                    "p_b_ratio":35.0,
+                    "dividend_yield":0.005
+                  }]
+                }
+              }
+            ]
+          }
+        ]"#;
+        let parsed: Vec<RatiosResponse> = serde_json::from_str(json).expect("parse");
+        let vr = parsed[0].results[0]
+            .tables
+            .as_ref()
+            .and_then(|t| t.valuation_ratios.clone())
+            .expect("vr")
+            .into_vec();
+        assert_eq!(vr[0].p_e_ratio, Some(28.5));
+    }
+
+    #[test]
+    fn test_financials_parses_real_shape() {
+        let json = r#"[
+          {
+            "request":"AAPL",
+            "type":"Symbol",
+            "results":[
+              {
+                "type":"Stock",
+                "tables":{
+                  "income_statement":[{
+                    "period":"FY",
+                    "report_type":"A",
+                    "fiscal_year_end":9,
+                    "filing_date":"2023-11-03",
+                    "form_type":"10-K",
+                    "period_ending_date":"2023-09-30"
+                  }]
+                }
+              }
+            ]
+          }
+        ]"#;
+        let parsed: Vec<FinancialsResponse> = serde_json::from_str(json).expect("parse");
+        let income = parsed[0].results[0]
+            .tables
+            .as_ref()
+            .and_then(|t| t.income_statement.clone())
+            .expect("income")
+            .into_vec();
+        assert_eq!(income[0].form_type.as_deref(), Some("10-K"));
+    }
+
+    #[test]
+    fn test_statistics_parses_real_shape() {
+        let json = r#"[
+          {
+            "request":"AAPL",
+            "type":"Symbol",
+            "results":[
+              {
+                "type":"Stock",
+                "tables":{
+                  "price_statistics":[{
+                    "period":"52W",
+                    "as_of_date":"2024-04-01",
+                    "close_price":170.25,
+                    "high_price":199.62,
+                    "low_price":124.17
+                  }]
+                }
+              }
+            ]
+          }
+        ]"#;
+        let parsed: Vec<StatisticsResponse> = serde_json::from_str(json).expect("parse");
+        let stats = parsed[0].results[0]
+            .tables
+            .as_ref()
+            .and_then(|t| t.price_statistics.clone())
+            .expect("stats")
+            .into_vec();
+        assert_eq!(stats[0].close_price, Some(170.25));
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(16))]
+
+        #[test]
+        fn test_deserialize_company_response_array(wire in any::<CompanyResponseArrayWire>()) {
+            let json = serde_json::to_string(&wire).expect("serialize");
+            let result: std::result::Result<Vec<CompanyResponse>, serde_json::Error> =
+                serde_json::from_str(&json);
+            prop_assert!(result.is_ok(), "failed: {:?}, json: {}", result, json);
+        }
+
+        #[test]
+        fn test_deserialize_corporate_calendar_response_array(
+            wire in any::<CorporateCalendarResponseArrayWire>()
+        ) {
+            let json = serde_json::to_string(&wire).expect("serialize");
+            let result: std::result::Result<Vec<CorporateCalendarResponse>, serde_json::Error> =
+                serde_json::from_str(&json);
+            prop_assert!(result.is_ok(), "failed: {:?}", result);
+        }
+
+        #[test]
+        fn test_deserialize_dividend_response_array(wire in any::<DividendResponseArrayWire>()) {
+            let json = serde_json::to_string(&wire).expect("serialize");
+            let result: std::result::Result<Vec<DividendResponse>, serde_json::Error> =
+                serde_json::from_str(&json);
+            prop_assert!(result.is_ok(), "failed: {:?}", result);
+        }
+
+        #[test]
+        fn test_deserialize_corporate_action_response_array(
+            wire in any::<CorporateActionResponseArrayWire>()
+        ) {
+            let json = serde_json::to_string(&wire).expect("serialize");
+            let result: std::result::Result<Vec<CorporateActionResponse>, serde_json::Error> =
+                serde_json::from_str(&json);
+            prop_assert!(result.is_ok(), "failed: {:?}", result);
+        }
+
+        #[test]
+        fn test_deserialize_ratios_response_array(wire in any::<RatiosResponseArrayWire>()) {
+            let json = serde_json::to_string(&wire).expect("serialize");
+            let result: std::result::Result<Vec<RatiosResponse>, serde_json::Error> =
+                serde_json::from_str(&json);
+            prop_assert!(result.is_ok(), "failed: {:?}", result);
+        }
+
+        #[test]
+        fn test_deserialize_financials_response_array(
+            wire in any::<FinancialsResponseArrayWire>()
+        ) {
+            let json = serde_json::to_string(&wire).expect("serialize");
+            let result: std::result::Result<Vec<FinancialsResponse>, serde_json::Error> =
+                serde_json::from_str(&json);
+            prop_assert!(result.is_ok(), "failed: {:?}", result);
+        }
+
+        #[test]
+        fn test_deserialize_statistics_response_array(
+            wire in any::<StatisticsResponseArrayWire>()
+        ) {
+            let json = serde_json::to_string(&wire).expect("serialize");
+            let result: std::result::Result<Vec<StatisticsResponse>, serde_json::Error> =
+                serde_json::from_str(&json);
+            prop_assert!(result.is_ok(), "failed: {:?}", result);
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,6 +24,17 @@ mod watchlists;
 pub mod types {
     pub use crate::accounts::types::*;
     pub use crate::common::SortOrder;
+    pub use crate::fundamentals::types::{
+        AssetClassification, CashDividend, CompanyProfile, CompanyResponse, CompanyResult,
+        CompanyTables, CorporateActionResponse, CorporateActionResult, CorporateActionTables,
+        CorporateCalendarEvent, CorporateCalendarResponse, CorporateCalendarResult,
+        CorporateCalendarTables, DividendResponse, DividendResult, DividendTables, EarningRatios,
+        FinancialStatement, FinancialsResponse, FinancialsResult, FinancialsTables,
+        FundamentalsEnvelope, Headquarter, MergerAcquisition, OperationRatios, PriceStatistics,
+        RatiosResponse, RatiosResult, RatiosTables, ShareClass, ShareClassProfile,
+        StatisticsResponse, StatisticsResult, StatisticsTables, StockSplit, TrailingReturns,
+        ValuationRatios,
+    };
     pub use crate::market_data::types::*;
     pub use crate::user::types::*;
     pub use crate::utils::OneOrMany;
@@ -32,6 +43,7 @@ pub mod blocking {
     pub use super::client::blocking::BlockingTradierRestClient as Client;
     pub mod operation {
         pub use crate::accounts::api::blocking::Accounts;
+        pub use crate::fundamentals::api::blocking::Fundamentals;
         pub use crate::market_data::api::blocking::MarketData;
         pub use crate::user::api::blocking::User;
     }
@@ -41,6 +53,7 @@ pub mod non_blocking {
     pub use super::client::non_blocking::TradierRestClient as Client;
     pub mod operation {
         pub use crate::accounts::api::non_blocking::Accounts;
+        pub use crate::fundamentals::api::non_blocking::Fundamentals;
         pub use crate::market_data::api::non_blocking::MarketData;
         pub use crate::user::api::non_blocking::User;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub use error::{Error, Result};
 mod accounts;
 mod client;
 pub mod common;
+mod fundamentals;
 mod market_data;
 mod streaming;
 mod trading;

--- a/src/market_data/types.rs
+++ b/src/market_data/types.rs
@@ -3,96 +3,15 @@
 //! See upstream documentation at
 //! <https://documentation.tradier.com/brokerage-api/markets/>.
 
-use std::str::FromStr;
-
 use chrono::{DateTime, NaiveDate, Utc};
 use serde::Deserialize;
 
+pub use crate::common::{Symbol, Symbols};
 use crate::utils::OneOrMany;
 
 // -----------------------------------------------------------------------------
 // Shared newtypes & enums
 // -----------------------------------------------------------------------------
-
-/// A ticker symbol (equity, option, index, etc.).
-///
-/// Tradier symbols are ASCII printable strings; this wrapper validates the
-/// input and rejects empty / blank values.
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct Symbol(String);
-
-impl Symbol {
-    /// Returns the inner string slice.
-    #[inline]
-    #[must_use]
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-}
-
-impl FromStr for Symbol {
-    type Err = crate::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s.trim().is_empty() {
-            Err(crate::Error::MarketDataParseError(format!(
-                "invalid symbol: '{s}' must not be empty or blank"
-            )))
-        } else if s.chars().all(|c| (0x20u8..0x7fu8).contains(&(c as u8))) {
-            Ok(Self(s.to_string()))
-        } else {
-            Err(crate::Error::MarketDataParseError(format!(
-                "invalid symbol: '{s}' must be printable ASCII"
-            )))
-        }
-    }
-}
-
-impl std::fmt::Display for Symbol {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-/// Comma-separated collection of [`Symbol`]s used by quote endpoints.
-#[derive(Clone, Debug, Default, PartialEq)]
-pub struct Symbols(Vec<Symbol>);
-
-impl Symbols {
-    /// Creates a new [`Symbols`] from an iterator of [`Symbol`].
-    #[must_use]
-    pub fn new(symbols: impl IntoIterator<Item = Symbol>) -> Self {
-        Self(symbols.into_iter().collect())
-    }
-
-    /// Returns the inner slice of [`Symbol`] values.
-    #[inline]
-    #[must_use]
-    pub fn as_slice(&self) -> &[Symbol] {
-        &self.0
-    }
-
-    /// Returns `true` if no symbols have been added.
-    #[inline]
-    #[must_use]
-    pub fn is_empty(&self) -> bool {
-        self.0.is_empty()
-    }
-}
-
-impl std::fmt::Display for Symbols {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut first = true;
-        for s in &self.0 {
-            if !first {
-                f.write_str(",")?;
-            }
-            f.write_str(s.as_str())?;
-            first = false;
-        }
-        Ok(())
-    }
-}
 
 /// Controls whether to include Greeks on option quote responses.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -805,44 +724,6 @@ mod test {
         GetTimeAndSalesResponseWire, LookupOptionSymbolsResponseWire, LookupSymbolResponseWire,
         SearchCompaniesResponseWire,
     };
-
-    #[test]
-    fn test_symbol_empty_should_error() {
-        let result: Result<Symbol, _> = "".parse();
-        assert!(result.is_err());
-        let result: Result<Symbol, _> = "   ".parse();
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_symbol_valid_should_succeed() {
-        let result: Result<Symbol, _> = "AAPL".parse();
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap().as_str(), "AAPL");
-    }
-
-    #[test]
-    fn test_symbol_rejects_non_ascii() {
-        let result: Result<Symbol, _> = "BAD\u{80}".parse();
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_symbols_display_comma_separated() {
-        let syms = Symbols::new(vec![
-            "AAPL".parse().unwrap(),
-            "MSFT".parse().unwrap(),
-            "GOOG".parse().unwrap(),
-        ]);
-        assert_eq!(syms.to_string(), "AAPL,MSFT,GOOG");
-    }
-
-    #[test]
-    fn test_symbols_empty_display() {
-        let syms = Symbols::default();
-        assert_eq!(syms.to_string(), "");
-        assert!(syms.is_empty());
-    }
 
     #[test]
     fn test_history_interval_display_values() {


### PR DESCRIPTION
## Summary

Implements the seven Tradier beta Fundamentals REST endpoints in one PR, following the pattern established by the market_data work in PR #29.

### Endpoints

| HTTP | Path | Trait method |
| --- | --- | --- |
| `GET` | `/beta/markets/fundamentals/company` | `get_company` |
| `GET` | `/beta/markets/fundamentals/corporate_calendars` | `get_corporate_calendars` |
| `GET` | `/beta/markets/fundamentals/dividends` | `get_dividends` |
| `GET` | `/beta/markets/fundamentals/corporate_actions` | `get_corporate_actions` |
| `GET` | `/beta/markets/fundamentals/ratios` | `get_ratios` |
| `GET` | `/beta/markets/fundamentals/financials` | `get_financials` |
| `GET` | `/beta/markets/fundamentals/statistics` | `get_statistics` |

All seven are exposed under both `non_blocking::operation::Fundamentals` and `blocking::operation::Fundamentals`, accept `&[Symbol]`, and return `Vec<T>` of endpoint-specific response envelopes.

### Module layout

- `src/fundamentals/types.rs` — request / response domain types and a generic `FundamentalsEnvelope<T>` wrapping each endpoint's array element.
- `src/fundamentals/api.rs` — the `Fundamentals` trait in both namespaces.
- `src/fundamentals/test_support.rs` — `*Wire` fixtures with `proptest_derive::Arbitrary`, flattened at the `tables` layer so the fuzzed strategy tree fits inside the default test-thread stack. Per-table shapes are covered by hand-written fixture tests in `types.rs`.
- `src/fundamentals/get_{company,corporate_calendars,dividends,corporate_actions,ratios,financials,statistics}_schema.json` — JSON Schemas co-located with the module.
- `src/client/{blocking,non_blocking}.rs` — `Fundamentals` impls on both clients, sharing the CSV-symbols helper.
- `src/lib.rs` — re-exports the trait and response types.

Per `CLAUDE.md`, `fundamentals/` only depends on `client/`, `common/`, `error/`, `utils/`. The `Symbol` / `Symbols` newtypes were first promoted into `common` (commit 1) so sibling endpoint modules do not depend on each other.

### Test matrix

For every endpoint the `client::blocking::fundamentals_tests` module adds:

- happy path via property-generated JSON (verifies the `symbols` query parameter and `accept: application/json` header are sent over the wire)
- 4xx (bad request / unauthorized)
- 5xx (server error)
- malformed body (non-JSON 200)

In addition, `fundamentals::types::test` has hand-written fixture tests exercising the real shape of each endpoint's `tables` sub-object, and `fundamentals::test_support::test` runs per-schema proptests that check serialized fixtures conform to the co-located JSON Schema. A single network-refused test exercises the transport error path.

### Gates

- `cargo build --release` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo test --all-features` — 217 passed, 0 failed

### Notes

- No new runtime dependencies.
- Nothing calls the real Tradier API.
- Pattern mirrors PR #29 (market_data) end-to-end.
- Does not touch the still-open streaming work from #11 / PR #30.

Closes #13