### PR TITLE
ci(changelog): fix broken workflow — install git-cliff binary directly

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -18,15 +18,20 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate CHANGELOG.md
-        uses: orhun/git-cliff-action@v3
-        id: cliff
-        with:
-          config: cliff.toml
-          args: --verbose
+      - name: Install git-cliff
         env:
-          OUTPUT: CHANGELOG.md
-          GITHUB_REPO: ${{ github.repository }}
+          GIT_CLIFF_VERSION: "2.12.0"
+        run: |
+          set -euo pipefail
+          curl -fsSL \
+            "https://github.com/orhun/git-cliff/releases/download/v${GIT_CLIFF_VERSION}/git-cliff-${GIT_CLIFF_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            -o git-cliff.tar.gz
+          tar -xzf git-cliff.tar.gz
+          sudo mv "git-cliff-${GIT_CLIFF_VERSION}/git-cliff" /usr/local/bin/git-cliff
+          git-cliff --version
+
+      - name: Generate CHANGELOG.md
+        run: git-cliff --config cliff.toml --verbose --output CHANGELOG.md
 
       - name: Commit and push updated CHANGELOG
         run: |


### PR DESCRIPTION
## Summary

The post-tag changelog workflow failed on \`v0.2.0\` because \`orhun/git-cliff-action@v3\` ships a Docker image built on Debian **buster**, whose apt mirrors now return 404 (buster has been archived). The \`apt-get update && apt-get install -y jq\` step in the image's Dockerfile fails with \`404 Not Found\` and the job aborts.

Fix: stop using the Docker-based action, install the official \`git-cliff\` 2.12.0 binary release from GitHub directly on \`ubuntu-latest\`, and call \`git-cliff\` as a plain CLI.

## Failing run

https://github.com/joaquinbejar/tradier/actions/runs/24638573541

## Test plan

- [x] Review diff — only \`.github/workflows/changelog.yml\` touched.
- [ ] Merge and trigger the workflow via \`workflow_dispatch\` to confirm \`CHANGELOG.md\` regeneration works end-to-end against tag \`v0.2.0\`.
- [ ] Next release tag should regenerate \`CHANGELOG.md\` automatically.